### PR TITLE
Fix vas_gzip_settup_attr

### DIFF
--- a/gzip_vas.c
+++ b/gzip_vas.c
@@ -99,8 +99,6 @@ static int open_device_nodes(char *devname, int pri, struct nx_handle *handle)
 	memset(&txattr, 0, sizeof(txattr));
 	txattr.version = 1;
 	txattr.vas_id = pri;
-	txattr.tc_mode  = 0;
-	txattr.rsvd_txbuf = 0;
 	rc = ioctl(fd, VAS_GZIP_TX_WIN_OPEN, (unsigned long)&txattr);
 	if (rc < 0) {
 		fprintf(stderr, "ioctl() n %d, error %d\n", rc, errno);

--- a/inc_nx/nx-gzip.h
+++ b/inc_nx/nx-gzip.h
@@ -23,12 +23,9 @@
 struct vas_gzip_setup_attr {
 	int32_t		version;
 	int16_t		vas_id;
-	int64_t		reserved1;
+	int16_t		reserved1;
 	int64_t		flags;
-	int64_t		reserved2;
-	int32_t		tc_mode;
-	int32_t		rsvd_txbuf;
-	int64_t		reserved3[6];
+	int64_t		reserved2[6];
 };
 
 #endif /* _UAPI_MISC_VAS_H */

--- a/selftest/inc/nx-gzip.h
+++ b/selftest/inc/nx-gzip.h
@@ -23,12 +23,9 @@
 struct vas_gzip_setup_attr {
 	int32_t		version;
 	int16_t		vas_id;
-	int64_t		reserved1;
+	int16_t		reserved1;
 	int64_t		flags;
-	int64_t		reserved2;
-	int32_t		tc_mode;
-	int32_t		rsvd_txbuf;
-	int64_t		reserved3[6];
+	int64_t		reserved2[6];
 };
 
 #endif /* _UAPI_MISC_VAS_H */


### PR DESCRIPTION
Last kernel patches changes the vas_tx_win_open_attr struct, this
patches changes our struct to be compatible with the last kernel.

NOTE: After this patch is applied the library will not work with the old kernel patches.