### PR TITLE
Use a pratical timeout value for page fault retries

### DIFF
--- a/lib/Versions
+++ b/lib/Versions
@@ -58,6 +58,7 @@ LIBNXZ_0.61.0 {
     nx_touch_pages_dde;
     nx_append_dde;
     nx_print_dde;
+    nx_wait_ticks;
     gzip_header_blank;
     fill_zero_lzcounts;
     fill_zero_len_dist;

--- a/lib/gzip_vas.c
+++ b/lib/gzip_vas.c
@@ -175,7 +175,8 @@ int nx_function_end(void *handle)
    the function may usleep() for about 1/4 of the accumulated time to
    reduce cpu utilization
 */
-static uint64_t nx_wait_ticks(uint64_t ticks, uint64_t accumulated_ticks, int do_sleep)
+uint64_t nx_wait_ticks(uint64_t ticks, uint64_t accumulated_ticks,
+			int do_sleep)
 {
 	uint64_t ts, te, mhz, sleep_overhead, sleep_threshold;
 

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -113,7 +113,7 @@ struct nx_config_t {
 	int 	 deflate_fifo_in_len;
 	int 	 deflate_fifo_out_len;
 	int      window_max;
-	int      pgfault_retries;
+	int      timeout_pgfaults;
 	int      verbose;
 	int      mlock_nx_crb_csb;
 	int      csb_poll_max;
@@ -465,6 +465,7 @@ static inline double nxtime_to_us(uint64_t nxtime)
 extern void *nx_fault_storage_address;
 extern void *nx_function_begin(int function, int pri);
 extern int nx_function_end(void *vas_handle);
+extern uint64_t nx_wait_ticks(uint64_t ticks, uint64_t accumulated_ticks, int do_sleep);
 
 /* zlib crc32.c and adler32.c */
 extern unsigned long nx_crc32_combine(unsigned long crc1, unsigned long crc2, uint64_t len2);

--- a/test/nx-zlib.conf
+++ b/test/nx-zlib.conf
@@ -37,5 +37,6 @@ logfile = ./nx.log
 # number of retries if vas_paste() failed. default: 5000
 #paste_retries = 5000
 
-# number of retries if nx_submit_job() returns ERR_NX_TRANSLATION. default: INT_MAX
-#pgfault_retries = 2147483647
+# timeout in seconds for retries if nx_submit_job() returns ERR_NX_TRANSLATION.
+# default: 300
+#timeout_pgfaults = 300


### PR DESCRIPTION
Changes the page fault retries to stop after a configurable
timeout instead of number of retries. The default value is
300 seconds.

---

I'm using 300 seconds as default but I'm not sure this is the
best value, any other suggestions?