### PR TITLE
Avoid building unnecessary files during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ $(subdirs):
 		$(MAKE) -C $@ || exit 1;	 	\
 	fi
 
+bench: $(subdirs)
+	$(MAKE) -C samples $@
+
 check:  $(subdirs)
 	$(MAKE) -C test $@
 
@@ -18,4 +21,3 @@ clean:
 			$(MAKE) -C $$dir $@ || exit 1;	\
 		fi					\
 	done
-

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -10,7 +10,9 @@ DHT_O = gzip_nxdht.o gzip_vas.o nx_dht.o nx_dht_builtin.o nx_dhtgen.o
 FHT_O = gzip_nxfht.o gzip_vas.o
 GUN_O = gunzip_nx.o gzip_vas.o
 
-all:	$(TESTS) zpipe gzm nx_gzip
+all:
+
+bench: $(TESTS) zpipe gzm nx_gzip
 
 gzip_vas.o:	../lib/gzip_vas.c
 	$(CC) $(CFLAGS) $(NXFLAGS) -I$(INC) -c ../lib/gzip_vas.c

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,7 +18,7 @@ TEST_OBJS = $(sort $(obj_test_deflate) $(obj_test_inflate) $(obj_test_stress) \
     $(obj_test_crc32) $(obj_test_adler32) $(obj_test_multithread_stress))
 EXE = test_inflate test_deflate test_stress test_crc32 test_adler32 test_multithread_stress
 
-all: $(EXE)
+all:
 
 check: $(EXE)
 	./run_test.sh


### PR DESCRIPTION
Some files for samples/ and test/ were getting built unnecessarily when
calling make.
Furthermore, some of these files depend on the availability of the
libraries, causing errors when calling make with a high number of jobs.

This patch also introduces target bench, which allows to build files
related to benchmarks.

Fixes PR #7 .