### PR TITLE
Test case to recreate kernel oops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ $(subdirs):
 check:  $(subdirs)
 	$(MAKE) -C test $@
 
+unsafe-check:  $(subdirs)
+	$(MAKE) -C test $@
+
 clean:
 	@for dir in $(subdirs); do 			\
 		if [ -d $$dir ]; then			\

--- a/test/Makefile
+++ b/test/Makefile
@@ -17,17 +17,21 @@ obj_test_multithread_stress = ${patsubst %.c, %.o, test_multithread_stress.c}
 TEST_OBJS = $(sort $(obj_test_deflate) $(obj_test_inflate) $(obj_test_stress) \
     $(obj_test_crc32) $(obj_test_adler32) $(obj_test_multithread_stress))
 EXE = test_inflate test_deflate test_stress test_crc32 test_adler32 test_multithread_stress
+UNSAFE = test_stress
 
 all: $(EXE)
 
 check: $(EXE)
 	./run_test.sh
 
+unsafe-check: $(UNSAFE)
+	./run_system_check.sh
+
 $(TEST_OBJS): %.o : %.c
 	$(CC) $(CFLAGS) $(INC) -c $^ -o $@
 
 clean:
-	/bin/rm -f *.o deflate/*.o inflate/*.o $(EXE) *.log
+	/bin/rm -f *.o deflate/*.o inflate/*.o $(EXE) $(UNSAFE) *.log
 
 .SECONDEXPANSION:
 test_%: $$(obj_$$@)

--- a/test/run_system_check.sh
+++ b/test/run_system_check.sh
@@ -1,0 +1,10 @@
+export NX_GZIP_CONFIG=./nx-zlib.conf
+export LD_LIBRARY_PATH=../lib:$LD_LIBRARY_PATH
+
+TS=$(date +"%F-%H-%M-%S")
+run_test_log=run_system_check_${TS}.log
+> $run_test_log
+
+echo "Testing for kernel oops..."
+NX_GZIP_CSB_POLL_MAX=200 ./test_stress  >> $run_test_log 2>&1
+echo "Passed!"

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
     exit 1;
 fi
 echo "running test_stress..."
-NX_GZIP_CSB_POLL_MAX=200 ./test_stress  >> $run_test_log 2>&1
+./test_stress  >> $run_test_log 2>&1
 echo "running test_crc32..."
 ./test_crc32   >> $run_test_log 2>&1
 if [ $? -ne 0 ]; then

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
     exit 1;
 fi
 echo "running test_stress..."
-./test_stress  >> $run_test_log 2>&1
+NX_GZIP_CSB_POLL_MAX=200 ./test_stress  >> $run_test_log 2>&1
 echo "running test_crc32..."
 ./test_crc32   >> $run_test_log 2>&1
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
There was a bug in kernel that caused a kernel oops if THP was
enabled.
Set csb_poll_max to 200, test_stress will trigger kernel oops if
the kernel doesn't have fix.