### PR TITLE
Include stdlib into libnxz.h

### DIFF
--- a/libnxz.h
+++ b/libnxz.h
@@ -36,6 +36,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdlib.h>
 
 #ifndef _LIBNXZ_H
 #define _LIBNXZ_H


### PR DESCRIPTION
libnxz.h uses the ulong type that is defined by stdlib.h.

---

An alternative solution would be replace ulong for unsigned long.