### PR TITLE
Use proper error code to check fault address

### DIFF
--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -1476,8 +1476,8 @@ restart:
 	}
 
 	switch (cc) {
-	case ERR_NX_TRANSLATION:
-		prt_warn("ERR_NX_TRANSLATION: bytes_in %d nxcmdp->crb.csb.fsaddr %p\n",
+	case ERR_NX_AT_FAULT:
+		prt_warn("ERR_NX_AT_FAULT: bytes_in %d nxcmdp->crb.csb.fsaddr %p\n",
 			bytes_in, (void *)nxcmdp->crb.csb.fsaddr);
 
 #ifdef NX_LOG_SOURCE_TARGET
@@ -1520,7 +1520,7 @@ restart:
 				goto err_exit;
 			}
 			else {
-				prt_warn("ERR_NX_TRANSLATION: Retry again\n");
+				prt_warn("ERR_NX_AT_FAULT: Retry again\n");
 				goto restart;
 			}
 		}

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -1147,7 +1147,7 @@ restart_nx:
 
 	switch (cc) {
 
-	case ERR_NX_TRANSLATION:
+	case ERR_NX_AT_FAULT:
 
 		/* We touched the pages ahead of time. In the most
 		   common case we shouldn't be here. But may be some
@@ -1155,7 +1155,7 @@ restart_nx:
 		   faulting address to fsaddr */
 		print_dbg_info(s, __LINE__);
 
-		prt_warn("ERR_NX_TRANSLATION: crb.csb.fsaddr %p source_sz %d ",
+		prt_warn("ERR_NX_AT_FAULT: crb.csb.fsaddr %p source_sz %d ",
 			 (void *)cmdp->crb.csb.fsaddr, source_sz);
 		prt_warn("target_sz %d\n", target_sz);
 #ifdef NX_LOG_SOURCE_TARGET
@@ -1203,7 +1203,7 @@ restart_nx:
 				goto err5;
 			}
 			else {
-				prt_warn("ERR_NX_TRANSLATION: more retry\n");
+				prt_warn("ERR_NX_AT_FAULT: more retry\n");
 				goto restart_nx;
 			}
 		}

--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -461,7 +461,7 @@ int nx_submit_job(nx_dde_t *src, nx_dde_t *dst, nx_gzip_crb_cpb_t *cmdp, void *h
 	   times out */
 	if (cc) {
 		prt_err("%s:%d job did not complete in allotted time, cc %d\n", __FUNCTION__, __LINE__, cc);
-		cc = ERR_NX_TRANSLATION; /* this will force resubmit */
+		cc = ERR_NX_AT_FAULT; /* this will force resubmit */
 		/* return cc; */
 		exit(-1); /* safely exit and let hadoop deal with dead job */
 	}
@@ -915,7 +915,7 @@ void nx_hw_init(void)
 	char *strategy_ovrd  = getenv("NX_GZIP_STRATEGY"); /* Z_FIXED: 0, Z_DEFAULT_STRATEGY: 1 */
 	char *csb_poll_max = getenv("NX_GZIP_CSB_POLL_MAX"); /* maximum poll number before wait_for_csb() timeout */
 	char *paste_retries = getenv("NX_GZIP_PASTE_RETRIES"); /* number of retries if vas_paste() failed */
-	/* number of retries if nx_submit_job() returns ERR_NX_TRANSLATION */
+	/* number of retries if nx_submit_job() returns ERR_NX_AT_FAULT */
 	char *timeout_pgfaults = getenv("NX_GZIP_TIMEOUT_PGFAULTS");
 
 	/* Init nx_config a default value firstly */
@@ -1178,7 +1178,7 @@ static inline int __nx_copy(char *dst, char *src, uint32_t len, uint32_t *crc, u
 		if (!!crc) *crc     = get32( cmd.cpb, out_crc );
 		if (!!adler) *adler = get32( cmd.cpb, out_adler );
 	}
-	else if ((cc == ERR_NX_TRANSLATION) && (ticks_total > (timeout_pgfaults
+	else if ((cc == ERR_NX_AT_FAULT) && (ticks_total > (timeout_pgfaults
 			    * __ppc_get_timebase_freq()))) {
 		ticks_total = nx_wait_ticks(500, ticks_total, 0);
 		goto restart_copy;

--- a/samples/gunzip_nx.c
+++ b/samples/gunzip_nx.c
@@ -947,12 +947,12 @@ restart_nx:
 	
 	switch (cc) {
 
-	case ERR_NX_TRANSLATION:
+	case ERR_NX_AT_FAULT:
 
 		/* We touched the pages ahead of time. In the most common case we shouldn't
 		   be here. But may be some pages were paged out. Kernel should have 
 		   placed the faulting address to fsaddr */
-		NXPRT( fprintf(stderr, "ERR_NX_TRANSLATION %p\n", (void *)cmdp->crb.csb.fsaddr) );
+		NXPRT( fprintf(stderr, "ERR_NX_AT_FAULT %p\n", (void *)cmdp->crb.csb.fsaddr) );
 		NX_CLK( (td.faultc += 1) );
 
 		/* Touch 1 byte, read-only  */

--- a/samples/gzip_nxdht.c
+++ b/samples/gzip_nxdht.c
@@ -401,13 +401,13 @@ int compress_file(int argc, char **argv, void *handle)
 
 		NX_CLK( (td.sub2 += (nx_get_time() - td.sub1)) );	
 		
-		if (cc != ERR_NX_OK && cc != ERR_NX_TPBC_GT_SPBC && cc != ERR_NX_TRANSLATION) {
+		if (cc != ERR_NX_OK && cc != ERR_NX_TPBC_GT_SPBC && cc != ERR_NX_AT_FAULT) {
 			fprintf(stderr, "nx error: cc= %d\n", cc);
 			exit(-1);
 		}
 
 		/* Page faults are handled by the user code */
-		if (cc == ERR_NX_TRANSLATION) {
+		if (cc == ERR_NX_AT_FAULT) {
 			volatile char touch = *(char *)cmdp->crb.csb.fsaddr;
 			NXPRT( fprintf(stderr, "page fault: cc= %d, try= %d, fsa= %08llx\n", cc, fault_tries, (long long unsigned) cmdp->crb.csb.fsaddr) );
 			NX_CLK( (td.fault += 1) );			

--- a/samples/gzip_nxfht.c
+++ b/samples/gzip_nxfht.c
@@ -352,13 +352,13 @@ int compress_file(int argc, char **argv, void *handle)
 
 		NX_CLK( (td.sub2 += (nx_get_time() - td.sub1)) );	
 		
-		if (cc != ERR_NX_OK && cc != ERR_NX_TPBC_GT_SPBC && cc != ERR_NX_TRANSLATION) {
+		if (cc != ERR_NX_OK && cc != ERR_NX_TPBC_GT_SPBC && cc != ERR_NX_AT_FAULT) {
 			fprintf(stderr, "nx error: cc= %d\n", cc);
 			exit(-1);
 		}
 
 		/* Page faults are handled by the user code */
-		if (cc == ERR_NX_TRANSLATION) {
+		if (cc == ERR_NX_AT_FAULT) {
 			volatile char touch = *(char *)cmdp->crb.csb.fsaddr;
 			NXPRT( fprintf(stderr, "page fault: cc= %d, try= %d, fsa= %08llx\n", cc, fault_tries, (long long unsigned) cmdp->crb.csb.fsaddr) );
 			NX_CLK( (td.fault += 1) );			

--- a/samples/nxlite.c
+++ b/samples/nxlite.c
@@ -592,13 +592,13 @@ static int nxlite_compress(char *dest, uint64_t *destLen,
 			lzcounts, cmdp,
 			myhandle->device_handle);
 
-		if (cc != ERR_NX_OK && cc != ERR_NX_TPBC_GT_SPBC && cc != ERR_NX_TRANSLATION && cc != ERR_NX_TARGET_SPACE) {
+		if (cc != ERR_NX_OK && cc != ERR_NX_TPBC_GT_SPBC && cc != ERR_NX_AT_FAULT && cc != ERR_NX_TARGET_SPACE) {
 			fprintf(stderr, "nx error: cc= %d\n", cc);
 			return Z_STREAM_ERROR; //exit(-1);
 		}
 		
 		/* Page faults are handled by the user code */
-		if (cc == ERR_NX_TRANSLATION) {
+		if (cc == ERR_NX_AT_FAULT) {
 			volatile char touch = *(char *)cmdp->crb.csb.fsaddr;
 			NXPRT( fprintf(stderr, "page fault: cc= %d, try= %d, fsa= %08llx\n", cc, fault_tries, (long long unsigned) cmdp->crb.csb.fsaddr) );
 			fault_tries --;
@@ -1170,12 +1170,12 @@ restart_nx:
 
 	switch (cc) {
 
-	case ERR_NX_TRANSLATION:
+	case ERR_NX_AT_FAULT:
 
 		/* We touched the pages ahead of time. In the most common case we shouldn't
 		   be here. But may be some pages were paged out. Kernel should have 
 		   placed the faulting address to fsaddr */
-		NXPRT( fprintf(stderr, "ERR_NX_TRANSLATION %p\n", (void *)cmdp->crb.csb.fsaddr) );
+		NXPRT( fprintf(stderr, "ERR_NX_AT_FAULT %p\n", (void *)cmdp->crb.csb.fsaddr) );
 
 		/* Touch 1 byte, read-only  */
 		nx_touch_pages( (void *)cmdp->crb.csb.fsaddr, 1, page_sz, 0);

--- a/samples/simpleapi/gzip_simple.c
+++ b/samples/simpleapi/gzip_simple.c
@@ -411,12 +411,12 @@ int p9deflate(p9_simple_handle_t *handle, void *src, void *dst, int srclen,
 	}
 
 	if (cc != ERR_NX_OK && cc != ERR_NX_TPBC_GT_SPBC
-	    && cc != ERR_NX_TRANSLATION) {
+	    && cc != ERR_NX_AT_FAULT) {
 		fprintf(stderr, "nx deflate error: cc= %d\n", cc);
 		return -1;
 	}
 
-	if (cc == ERR_NX_TRANSLATION) {
+	if (cc == ERR_NX_AT_FAULT) {
 		fprintf(stderr, "nx deflate error page fault: cc= %d\n", cc);
 		// TODO maybe handle page faults
 		return -1;

--- a/selftest/gunz_test.c
+++ b/selftest/gunz_test.c
@@ -725,13 +725,13 @@ restart_nx:
 
 	switch (cc) {
 
-	case ERR_NX_TRANSLATION:
+	case ERR_NX_AT_FAULT:
 
 		/* We touched the pages ahead of time.  In the most common case
 		 * we shouldn't be here.  But may be some pages were paged out.
 		 * Kernel should have placed the faulting address to fsaddr.
 		 */
-		NXPRT(fprintf(stderr, "ERR_NX_TRANSLATION %p\n",
+		NXPRT(fprintf(stderr, "ERR_NX_AT_FAULT %p\n",
 			      (void *)cmdp->crb.csb.fsaddr));
 
 		if (pgfault_retries == NX_MAX_FAULTS) {

--- a/selftest/gzfht_test.c
+++ b/selftest/gzfht_test.c
@@ -330,13 +330,13 @@ int compress_file(int argc, char **argv, void *handle)
 			lzcounts, cmdp, handle);
 
 		if (cc != ERR_NX_OK && cc != ERR_NX_TPBC_GT_SPBC &&
-		    cc != ERR_NX_TRANSLATION) {
+		    cc != ERR_NX_AT_FAULT) {
 			fprintf(stderr, "nx error: cc= %d\n", cc);
 			exit(-1);
 		}
 
 		/* Page faults are handled by the user code */
-		if (cc == ERR_NX_TRANSLATION) {
+		if (cc == ERR_NX_AT_FAULT) {
 			NXPRT(fprintf(stderr, "page fault: cc= %d, ", cc));
 			NXPRT(fprintf(stderr, "try= %d, fsa= %08llx\n",
 				  fault_tries,

--- a/test/nx-zlib.conf
+++ b/test/nx-zlib.conf
@@ -37,6 +37,6 @@ logfile = ./nx.log
 # number of retries if vas_paste() failed. default: 5000
 #paste_retries = 5000
 
-# timeout in seconds for retries if nx_submit_job() returns ERR_NX_TRANSLATION.
+# timeout in seconds for retries if nx_submit_job() returns ERR_NX_AT_FAULT.
 # default: 300
 #timeout_pgfaults = 300


### PR DESCRIPTION
The completion codes were fixed on kernel (#38), now ERR_NX_TRANSLATION
(CSB.CC=5) is only used for internal VAS faults handling and should
not used by libnxz. ERR_NX_AT_FAULT (CSB.CC=250) is the proper error
code reported by the kernel when NX encounters address translation
failure.