### PR TITLE
Keep libraries' symlinks when installing

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -36,7 +36,9 @@ clean:
 install: $(STATICLIB) $(SHAREDLIB)
 	install -d $(LIBDIR)
 	install -m 755 $(SHAREDLIB) $(LIBDIR)
-	install -m 755 $(SHAREDSONAMELIB) $(LIBDIR)
+	{ cd $(LIBDIR); \
+	  ln -s $(SHAREDLIB) $(SHAREDSONAMELIB); \
+	  ln -s $(SHAREDLIB) $(LIBLINK); }
 	install -m 644 $(STATICLIB) $(LIBDIR)
 
 uninstall:


### PR DESCRIPTION
The install command follows symbolic links and copy the target file
instead of the symlink itself.
This forces us to recreate the symlinks by hand at install time so that
they're kept intact.