### PR TITLE
Build nx_gzip binary with libnxz

### DIFF
--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -1222,3 +1222,8 @@ int nx_copy(char *dst, char *src, uint64_t len, uint32_t *crc, uint32_t *adler, 
 	if (!!adler) *adler = in_adler;
 	return cc;
 }
+
+const char * zlibVersion()
+{
+    return ZLIB_VERSION;
+}

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -93,6 +93,9 @@
 void nx_print_dde(nx_dde_t *ddep, const char *msg);
 #endif
 
+#define zlib_version zlibVersion()
+extern const char *zlibVersion OF((void));
+
 /* common config variables for all streams */
 struct nx_config_t {
 	long     page_sz;

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -64,7 +64,7 @@ rand_pfault_check: rand_pfault_check.c compdecomp_th.c ../lib/libnxz.a
 	rand_pfault_check.c compdecomp_th.c $(LDLIB)
 
 nx_gzip: nx_gzip.c
-	$(CC) $(CFLAGS) -o $@ $^ -lz
+	$(CC) $(CFLAGS) -I$(INC) $(LDFLAGS) -o $@ $^ $(LDLIB)
 
 clean:
 	rm -f $(TESTS) *.o *.c~ *.h~ Makefile~ zpipe compdecomp compdecomp_th makedata \


### PR DESCRIPTION
Update Makefile to build nx_gzip utility with libnxz.

To be able to build with no changes, added the zlibVersion method
to the library.

Signed-off-by: Carlos de Paula <me@carlosedp.com>