### PR TITLE
Update the documentation and enable -Wall -Werror

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -11,7 +11,7 @@ LD = $(shell which ld)
 
 ## Common flags
 FLG    = -std=gnu11
-SFLAGS = -O3 -fPIC
+SFLAGS = -O3 -Wall -Werror -Wno-error=pointer-sign -fPIC
 ZLIB   = -DZLIB_API
 
 ## Compiler related flags
@@ -23,4 +23,3 @@ ifeq "$(shell expr $(GCC_VER_MAIN) \>= 6)" "1"
 endif
 
 CFLAGS = $(FLG) $(SFLAGS) $(ZLIB) #-DNXTIMER
-

--- a/config.mk
+++ b/config.mk
@@ -11,7 +11,7 @@ LD = $(shell which ld)
 
 ## Common flags
 FLG    = -std=gnu11
-SFLAGS = -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN
+SFLAGS = -O3 -fPIC
 ZLIB   = -DZLIB_API
 
 ## Compiler related flags

--- a/doc/libnxz.doxy
+++ b/doc/libnxz.doxy
@@ -506,7 +506,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,

--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -852,6 +852,7 @@ static uint32_t nx_compress_nxstrm_to_ddl_out(nx_streamp s)
 }
 
 /* copies spbc, tpbc, in_histlen from cpb in to nx_streamp */
+static void nx_compress_block_get_cpb(nx_streamp s, int fc) __attribute__ ((unused));
 static void nx_compress_block_get_cpb(nx_streamp s, int fc)
 {
 	uint32_t spbc;

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -44,7 +44,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdint.h>

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -37,6 +37,11 @@
  *
  */
 
+/** @file nx_inflate.c
+ * \brief Implement the inflate function for the NX GZIP accelerator and
+ * related functions.
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <malloc.h>
@@ -57,11 +62,17 @@
 #include "nx_zlib.h"
 #include "nx_dbg.h"
 
-#define INF_HIS_LEN (1<<15) /* Fixed 32K history length */
+/** \brief Fixed 32K history length
+ * \details The maximum distance in the deflate standard is 32768 Bytes.
+ */
+#define INF_HIS_LEN (1<<15)
 #define INF_MAX_DICT_LEN  INF_HIS_LEN
 
 #define INF_MIN_INPUT_LEN 300 /* greater than 288 for dht plus 3 bit header plus 1 byte */
-#define INF_MAX_COMPRESSION_RATIO 1032 /* https://stackoverflow.com/a/42865320/5504692 */
+/** \brief Maximum Compression Ratio
+ * https://stackoverflow.com/a/42865320/5504692
+ */
+#define INF_MAX_COMPRESSION_RATIO 1032
 #define INF_MAX_EXPANSION_BYTES (INF_MIN_INPUT_LEN * INF_MAX_COMPRESSION_RATIO)
 
 /* move the overflow from the current fifo head-32KB to the fifo_out
@@ -868,6 +879,11 @@ static int nx_amend_history_with_dict(nx_streamp s, int *hlen, int *dlen )
 	return 0;
 }
 
+/** \brief Internal implementation of inflate.
+ *
+ * @param s nx_streamp to be processed.
+ * @param flush Determines when uncompressed bytes are added to next_out.
+ */
 static int nx_inflate_(nx_streamp s, int flush)
 {
 	/* queuing, file ops, byte counting */
@@ -886,7 +902,9 @@ static int nx_inflate_(nx_streamp s, int flush)
 
 	uint64_t ticks_total = 0;
 	int cc, rc, timeout_pgfaults, partial_bits=0;
-	int nx_history_len; /* includes dictionary and history going in to nx-gzip */
+	/** \brief Includes dictionary and history going in to nx-gzip
+	 */
+	int nx_history_len;
 
 	timeout_pgfaults = nx_config.timeout_pgfaults;
 

--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -773,7 +773,7 @@ FILE* open_logfile(char *filename)
 	if (!filename)
 		return NULL;
 	/* try to open in append mode */
-	if (logfile = fopen(filename, "a+")) {
+	if ((logfile = fopen(filename, "a+"))) {
 		/* ok, try to chmod so all users can access it.
 		 * the first process creating this file should success, others are expected to fail */
 		//fprintf(stderr, "try chmod: %s\n", filename);
@@ -787,7 +787,7 @@ FILE* open_logfile(char *filename)
 		/* file not exist, fall back to use /tmp/nx.log */
 		syslog(LOG_NOTICE, "nx-zlib: cannot open log file: %s, %s\n",
 			filename, strerror(errno));
-		if (logfile = fopen("/tmp/nx.log", "a+")) {
+		if ((logfile = fopen("/tmp/nx.log", "a+"))) {
 			//fprintf(stderr, "%s not exists, use /tmp/nx.log\n", filename);
 			/* ok, try to chmod so all users can access it. */
 			//fprintf(stderr, "try chmod: /tmp/nx.log\n");
@@ -799,7 +799,7 @@ FILE* open_logfile(char *filename)
 		syslog(LOG_NOTICE, "nx-zlib: cannot access log file: %s\n", filename);
 		/* file exists, we might have no access right, try to use /tmp/nx.log,
 		 * but this may fail if no right to access /tmp/log */
-		if (logfile = fopen("/tmp/nx.log", "a+")) {
+		if ((logfile = fopen("/tmp/nx.log", "a+"))) {
 			//fprintf(stderr, "use /tmp/nx.log\n");
 			return logfile;
 		}

--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -933,8 +933,6 @@ void nx_hw_init(void)
 	nx_config.strm_inf_bufsz = (1<<16); /* affect the inflate fifo_in and fifo_out */
 	nx_config.soft_copy_threshold = 1024; /* choose memcpy or hwcopy */
 	nx_config.compress_threshold = (10*1024); /* collect as much input */
-	nx_config.inflate_fifo_in_len = ((1<<16)*2); /* default 128K, half used */
-	nx_config.inflate_fifo_out_len = ((1<<24)*2); /* default 32M, half used */
 	nx_config.deflate_fifo_in_len = 1<<17; /* default 8M, half used */
 	nx_config.deflate_fifo_out_len = ((1<<21)*2); /* default 16M, half used */
 	nx_config.verbose = 0;
@@ -1059,11 +1057,6 @@ void nx_hw_init(void)
 		nx_dht_config = str_to_num(dht_config);
 		prt_info("DHT config set to 0x%x\n", nx_dht_config);
 	}
-
-	/* revalue the fifo_in and fifo_out */
-	nx_config.inflate_fifo_in_len  = (nx_config.strm_inf_bufsz * 2);
-	nx_config.inflate_fifo_out_len = (nx_config.strm_inf_bufsz * 2);
-	nx_config.deflate_fifo_out_len = (nx_config.strm_def_bufsz * 2);
 
 	/* If user is asking for a specific accelerator. Otherwise we
 	   accept the accelerator(s) assigned by kernel */

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -115,8 +115,6 @@ struct nx_config_t {
 	uint32_t strm_inf_bufsz;
 	uint32_t soft_copy_threshold;  /* choose memcpy or hwcopy */
 	uint32_t compress_threshold;   /* collect as much input */
-	int 	 inflate_fifo_in_len;
-	int 	 inflate_fifo_out_len;
 	int 	 deflate_fifo_in_len;
 	int 	 deflate_fifo_out_len;
 	int      window_max;

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -255,6 +255,10 @@ typedef struct nx_stream_s {
         int             z_rc;           /* libz return codes */
 
 	uint32_t        spbc;
+	/** \brief Target Processed Byte Count
+	 * \details Amount of target data bytes an accelerator has written in
+	 * processing this CRB.
+	 */
 	uint32_t        tpbc;
 	uint32_t        tebc;
 

--- a/test/deflate/compress.c
+++ b/test/deflate/compress.c
@@ -57,7 +57,8 @@ static int run(unsigned int len, int all, char digit, const char* test)
 
 	if (_test_nx_compress(compr, &compr_len, src, src_len)) goto err;
 	if (_test_uncompress(uncompr, &uncompr_len, compr, compr_len, src, src_len)) goto err;
-	// if (_test_nx_uncompress(uncompr, &uncompr_len, compr, compr_len, src, src_len)) goto err;
+	if (_test_nx_uncompress(uncompr, &uncompr_len, compr, compr_len, src,
+				src_len)) goto err;
 
 	printf("*** %s %s passed\n", __FILE__, test);
 	free(compr);

--- a/test/deflate/perf.c
+++ b/test/deflate/perf.c
@@ -244,5 +244,6 @@ int run_case41()
 	for (int i = 0; i < THREAD_NUM; i++) {
 		pthread_join(tid[i], NULL);
 	}
-}
 
+	return 0;
+}

--- a/test/inflate/random_buffer.c
+++ b/test/inflate/random_buffer.c
@@ -129,8 +129,8 @@ static int run(unsigned int len, int step, const char* test, int flush)
 		return TEST_ERROR;
 	}
 
-    if( (flush != Z_NO_FLUSH) && (flush != Z_PARTIAL_FLUSH) )
-	goto err;
+	if( (flush != Z_NO_FLUSH) && (flush != Z_PARTIAL_FLUSH) )
+		goto err;
 
 	if (_test_deflate(src, src_len, compr, compr_len, src_len)) goto err;
 	if (_test_inflate(compr, compr_len, uncompr, uncompr_len, src, src_len, step)) goto err;

--- a/test/test_multithread_stress.c
+++ b/test/test_multithread_stress.c
@@ -36,11 +36,6 @@ struct stats{
 };
 static struct stats thread_info[THREAD_MAX];
 
-
-static alloc_func zalloc = (alloc_func)0;
-static free_func zfree = (free_func)0;
-
-
 static float get_time_duration(struct timeval e, struct timeval s)
 {
 	return ((e.tv_sec - s.tv_sec) * 1000 + (e.tv_usec - s.tv_usec)/1000.0);
@@ -214,7 +209,6 @@ int main(int argc, char **argv)
 
 	int thread_num = THREAD_MAX;
 	unsigned long tsize = 0;
-	char *s;
 	int i;
 
 	if(argc != 4) {

--- a/test/test_multithread_stress.c
+++ b/test/test_multithread_stress.c
@@ -202,6 +202,8 @@ static int run_case()
 	pstats->iteration += 1;
 	pstats->running = 0;
 	//printf("thread %d exit...iteration:%d\n", pthread_self(),pstats->iteration);
+
+	return 0;
 }
 
 int main(int argc, char **argv)

--- a/test/test_stress.c
+++ b/test/test_stress.c
@@ -51,8 +51,6 @@ struct time_duration {
 static alloc_func zalloc = (alloc_func)0;
 static free_func zfree = (free_func)0;
 
-static pthread_mutex_t stress_mutex;
-
 static struct use_time* get_use_time_by_tid(pthread_t id)
 {
 	for (int i = 0; i < THREAD_MAX; i++){

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -24,7 +24,7 @@ static char dict[] = {
 	',', '.', '!', '?', '.', '{', '}'
 };
 
-int generate_all_data(int len, char digit)
+void generate_all_data(int len, char digit)
 {
 	assert(len > 0);
 
@@ -35,7 +35,7 @@ int generate_all_data(int len, char digit)
 	}
 }
 
-int generate_random_data(int len)
+void generate_random_data(int len)
 {
 	assert(len > 0);
 

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -1,9 +1,7 @@
-
 #define DATA_MAX_LEN (128*1024*1024) // 128M
 
 extern char ran_data[DATA_MAX_LEN];
-extern int generate_random_data(int len);
+extern void generate_random_data(int len);
 extern char* generate_allocated_random_data(unsigned int len);
-extern int generate_all_data(int len, char digit);
+extern void generate_all_data(int len, char digit);
 extern int compare_data(char* src, char* dest, int len);
-


### PR DESCRIPTION
This PR has 1 patch to add more documentation, 5 patches fixing warnings pointed out by the compiler and a last patch to enable `-Wall -Werror`.

Notice that, because of issue #56 , there are still warnings pending.