### PR TITLE
oct: Fix the final checksum output

### DIFF
--- a/oct/generate-test.sh
+++ b/oct/generate-test.sh
@@ -38,7 +38,7 @@ if [[ -z "\${checksum2}" ]]; then
   exit 1
 fi
 
-echo -e  "Final checksum:\t\${checksum1}"
+echo -e  "Final checksum:\t\t\${checksum2}"
 
 if [[ "\${checksum1}" != "\${checksum2}" ]]; then
   echo "Error: checksum did not match"


### PR DESCRIPTION
Print the correct checksum variable and fix the indentation of value in
order to be aligned with the previous output.