### PR TITLE
Add support for Valgrind and another small fix

### DIFF
--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -893,7 +893,7 @@ static int nx_inflate_(nx_streamp s, int flush)
 	uint32_t inflate_per_job_len = 64 * nx_config.per_job_len;
 
 	/* nx hardware */
-	uint32_t sfbt, subc, spbc, tpbc, nx_ce, fc;
+	uint32_t sfbt = 0, subc = 0, spbc, tpbc, nx_ce, fc;
 
 	nx_gzip_crb_cpb_t *cmdp = s->nxcmdp;
 	nx_dde_t *ddl_in = s->ddl_in;

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -1473,14 +1473,15 @@ offsets_state:
 			len = INF_HIS_LEN - (len_next_out + overflow_len);
 			/* len_next_out is the amount engine wrote next_out. */
 			/* Shifts fifo_out contents backwards towards
-			   the beginning. TODO check the logic for
-			   correctness when source and destination
-			   overlap; backward memcpy may be OK when
-			   overlapped? */
-			memcpy(s->fifo_out + s->cur_out - len_next_out - len, s->fifo_out + s->cur_out - len, len);
+			   the beginning. Use memmove because memory may
+			   overlap. */
+			memmove(s->fifo_out + s->cur_out - len_next_out - len,
+				s->fifo_out + s->cur_out - len, len);
 			/* copies from next_out to the gap opened in
-			   fifo_out as a result of previous memcpy */
-			memcpy(s->fifo_out + s->cur_out - len_next_out, s->next_out, len_next_out);
+			   fifo_out as a result of previous memmove. Also use
+			   memmove because memory may overlap. */
+			memmove(s->fifo_out + s->cur_out - len_next_out,
+				s->next_out, len_next_out);
 		}
 
 		s->used_out += overflow_len;

--- a/test/deflate/hello.c
+++ b/test/deflate/hello.c
@@ -24,6 +24,8 @@ int run_case1()
 			return TEST_ERROR;
 	}
 
+	free(compr);
+	free(uncompr);
 	printf("*** deflate %s passed\n", __func__);
 	return TEST_OK;
 }

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -9,39 +9,39 @@ run_test_report=run_test_report_${TS}.txt
 > $run_test_report
 
 echo "running test_deflate..."
-./test_deflate >> $run_test_log 2>&1
+$TEST_WRAPPER ./test_deflate >> $run_test_log 2>&1
 if [ $? -ne 0 ]; then
     echo "test_deflate failed."
     exit 1;
 fi
 echo "running test_inflate..."
-./test_inflate >> $run_test_log 2>&1
+$TEST_WRAPPER ./test_inflate >> $run_test_log 2>&1
 if [ $? -ne 0 ]; then
     echo "test_inflate failed."
     exit 1;
 fi
 echo "running test_stress..."
-./test_stress  >> $run_test_log 2>&1
+$TEST_WRAPPER ./test_stress  >> $run_test_log 2>&1
 echo "running test_crc32..."
-./test_crc32   >> $run_test_log 2>&1
+$TEST_WRAPPER ./test_crc32   >> $run_test_log 2>&1
 if [ $? -ne 0 ]; then
     echo "test_crc32 failed."
     exit 1;
 fi
 echo "running test_adler32..."
-./test_adler32 >> $run_test_log 2>&1
+$TEST_WRAPPER ./test_adler32 >> $run_test_log 2>&1
 if [ $? -ne 0 ]; then
     echo "test_adler32 failed."
     exit 1;
 fi
 echo "running test_multithread_stress..."
-./test_multithread_stress `nproc` 10 6  >> $run_test_log 2>&1
+$TEST_WRAPPER ./test_multithread_stress `nproc` 10 6  >> $run_test_log 2>&1
 if [ $? -ne 0 ]; then
     echo "test_multithread_stress failed."
     exit 1;
 fi
 echo "running test_pid_reuse..."
-./test_pid_reuse 2 >> $run_test_log 2>&1
+$TEST_WRAPPER ./test_pid_reuse 2 >> $run_test_log 2>&1
 if [ $? -ne 0 ]; then
     echo "test_pid_reuse failed."
     exit 1;
@@ -51,4 +51,3 @@ echo "------------------------------"
 grep -E 'run_case|failed' $run_test_log | tee -a $run_test_report
 
 grep -A 17 Thread $run_test_log | tee -a $run_test_report
-

--- a/test/valgrind.supp
+++ b/test/valgrind.supp
@@ -1,0 +1,5 @@
+{
+  compare_data
+  Memcheck:Cond
+  fun:compare_data
+}


### PR DESCRIPTION
Add a couple of patches to allow running libnxz tests against the latest Valgrind.
Notice that upstream Valgrind still does not support copy/paste instructions.

Fix some of the issues that have already been identified and ignore a false positive.

There is also a patch to suppress warning/error from older GCC versions.