### PR TITLE
Fix warnings reported by GCC in samples/

### DIFF
--- a/lib/nx_dht.c
+++ b/lib/nx_dht.c
@@ -79,7 +79,7 @@
 #define EOB 256     /* end of block symbol */
 
 typedef struct top_sym_t {
-	struct { 
+	struct {
 		uint32_t lzcnt;
 		int sym;
 	} sorted[3];
@@ -575,7 +575,9 @@ static int dht_lookup5(nx_gzip_crb_cpb_t *cmdp, int request, void *handle)
 	top_sym_t top[1];
 	dht_tab_t *dht_tab = (dht_tab_t *) handle;
 	dht_entry_t *dht_cache = dht_tab->cache;
-	
+
+	__builtin_bzero(top, sizeof(top_sym_t));
+
 	if (request == dht_default_req) {
 		/* first builtin entry is the default */
 		copy_dht_to_cpb(cmdp, &dht_tab->builtin[0]);
@@ -653,9 +655,9 @@ force_dhtgen:
 
 	/* save the dht identifying key */
 	dht_cache[clock].litlen[0] = top[llns].sorted[0].sym;
-	dht_cache[clock].litlen[1] = top[llns].sorted[1].sym;	
-	dht_cache[clock].litlen[2] = top[llns].sorted[2].sym;	
-	
+	dht_cache[clock].litlen[1] = top[llns].sorted[1].sym;
+	dht_cache[clock].litlen[2] = top[llns].sorted[2].sym;
+
 	dht_atomic_store( &dht_cache[clock].valid, 1 );
 
 	DHTPRT( fprintf(stderr, "dht_lookup: insert idx %d (litlen %d %d)\n", clock, dht_cache[clock].litlen[0],dht_cache[clock].litlen[1]));

--- a/lib/nx_dhtgen.c
+++ b/lib/nx_dhtgen.c
@@ -419,9 +419,11 @@ static int huffman_tree(uint32_t *hist, int nsym, huff_tree_t *htree)
 {
     leaf_node_t leafarr[NLEN]; /* [NLEN]; */
     tree_node_t nodearr[NLEN];
-    tree_node_t remaining_node = {0};
+    tree_node_t remaining_node;
     q_t leaf_q, node_q;
     int nz_nsym;
+
+    __builtin_bzero(&remaining_node, sizeof(tree_node_t));
 
     /* This is where we would copy in the CPBout buffer to dhtgen */
 

--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -639,7 +639,8 @@ static int nx_enumerate_engines()
 				fclose(f);
 				continue;
 			}
-			nx_devices[count].nx_id = be32toh(*(int *)buf);
+			int *tmp = (int *) buf;
+			nx_devices[count].nx_id = be32toh(*tmp);
 			fclose(f);
 
 			memset(vas_file,0,sizeof(vas_file));
@@ -657,7 +658,8 @@ static int nx_enumerate_engines()
 				fclose(f);
 				continue;
 			}
-			nx_devices[count].socket_id = be32toh(*(int *)buf);
+			tmp = (int *) buf;
+			nx_devices[count].socket_id = be32toh(*tmp);
 			fclose(f);
 
 			count++;

--- a/samples/compdecomp_th.c
+++ b/samples/compdecomp_th.c
@@ -104,7 +104,6 @@ int read_alloc_input_file(char *fname, char **buf, size_t *bufsize)
 int write_output_file(char *fname, char *buf, size_t bufsize)
 {
 	FILE *fp;
-	char *p;
 	size_t num_bytes;
 	if (NULL == (fp = fopen(fname, "w"))) {
 		perror(fname);
@@ -232,8 +231,10 @@ void *decomp_file_multith(void *argsv)
 	double elapsed;
 	thread_args_t *argsp = (thread_args_t *) argsv;
 	int tid;
+#ifdef SIMPLE_CHECKSUM
 	unsigned long cksum = 1;
-	
+#endif
+
 	inbuf = argsp->inbuf;
 	inlen = argsp->inlen;	
 	iterations = argsp->iterations;

--- a/samples/gzip_nxdht.c
+++ b/samples/gzip_nxdht.c
@@ -91,7 +91,7 @@ extern uint64_t dbgtimer;
 static int compress_dht_sample(char *src, uint32_t srclen, char *dst, uint32_t dstlen,
 			       int with_count, nx_gzip_crb_cpb_t *cmdp, void *handle)
 {
-	int i,cc;
+	int cc;
 	uint32_t fc;
 
 	assert(!!cmdp);
@@ -199,7 +199,6 @@ int read_alloc_input_file(char *fname, char **buf, size_t *bufsize)
 int write_output_file(char *fname, char *buf, size_t bufsize)
 {
 	FILE *fp;
-	char *p;
 	size_t num_bytes;
 	if (NULL == (fp = fopen(fname, "w"))) {
 		perror(fname);
@@ -289,11 +288,11 @@ int compress_file(int argc, char **argv, void *handle)
 	char outname[1024];
 	uint32_t srclen, dstlen;
 	uint32_t flushlen, chunk;
-	size_t inlen, outlen, dsttotlen, srctotlen;	
-	uint32_t adler, crc, spbc, tpbc, tebc;
+	size_t inlen, outlen, dsttotlen, srctotlen;
+	uint32_t crc=0, spbc, tpbc, tebc;
 	int lzcounts=1; /* always collect lzcounts */
 	int initial_pass;
-	int cc,fc;
+	int cc;
 	int num_hdr_bytes;
 	nx_gzip_crb_cpb_t nxcmd, *cmdp;
 	uint32_t pagelen = 65536; /* should get this with syscall */
@@ -408,9 +407,8 @@ int compress_file(int argc, char **argv, void *handle)
 
 		/* Page faults are handled by the user code */
 		if (cc == ERR_NX_AT_FAULT) {
-			volatile char touch = *(char *)cmdp->crb.csb.fsaddr;
 			NXPRT( fprintf(stderr, "page fault: cc= %d, try= %d, fsa= %08llx\n", cc, fault_tries, (long long unsigned) cmdp->crb.csb.fsaddr) );
-			NX_CLK( (td.fault += 1) );			
+			NX_CLK( (td.fault += 1) );
 
 			fault_tries --;
 			if (fault_tries > 0) {
@@ -419,7 +417,7 @@ int compress_file(int argc, char **argv, void *handle)
 			else {
 				fprintf(stderr, "error: cannot progress; too many faults\n");
 				exit(-1);
-			};			    
+			};
 		}
 
 		fault_tries = 50; /* reset for the next chunk */

--- a/samples/gzm.c
+++ b/samples/gzm.c
@@ -133,7 +133,6 @@ int def(FILE *source, FILE *dest, int level, gzcfg_t *cf)
 
     /* compress until end of file */
     do {
-	int toggle=0;
 	strm.avail_in = fread(in, 1, CHUNK, source);
 	if (ferror(source)) {
 	    (void)deflateEnd(&strm);
@@ -359,7 +358,7 @@ int main(int argc, char **argv)
    dest bytes in the dest buffer on return */
 int def_mb(char *source, char *dest, int *size_of_data, gzcfg_t *cf)
 {
-    int ret, flush, remainder, inp_size;
+    int ret, flush, remainder;
     unsigned have;
     z_stream strm;
     unsigned char in[CHUNK];

--- a/samples/nx_gzip.c
+++ b/samples/nx_gzip.c
@@ -593,7 +593,6 @@ int main(int argc, char **argv)
 	FILE *i_fp = stdin;
 	FILE *o_fp = NULL;
 	const char *suffix = "gz";
-	int force_software = 0;
 	unsigned char *in = NULL;
 	unsigned char *out = NULL;
 	z_stream strm;
@@ -672,9 +671,6 @@ int main(int argc, char **argv)
 			break;
 		case 'S':
 			suffix = optarg;
-			break;
-		case 's':
-			force_software = true;
 			break;
 		case 'l':
 			list_contents++;


### PR DESCRIPTION
1. Remove unused variables.
2. Guarantee variables are initialized before they're used.
3. Remove a few trailing whitespaces.