### PR TITLE
Addapt nx_enumerate_engines() to work with PowerVM

### DIFF
--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -665,6 +665,11 @@ static int nx_enumerate_engines()
 			count++;
 
 		}
+		/* On PowerVM, there is no concept of multiple NX engines.  */
+		if (strncmp(de->d_name, "ibm,powervm", 11) == 0){
+			closedir(d);
+			return 1;
+		}
 	}
 
 	closedir(d);


### PR DESCRIPTION
This patch detects the platform where libnxz is being built
and sets 1 NX engine for PowerVM on nx_enumerate_engines().
Fixes #62.

Signed-off-by: Raphael Moreira Zinsly <rzinsly@linux.ibm.com>