### PR TITLE
Fixes for test_multithread_stress

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -35,7 +35,8 @@ if [ $? -ne 0 ]; then
     exit 1;
 fi
 echo "running test_multithread_stress..."
-$TEST_WRAPPER ./test_multithread_stress `nproc` 10 6  >> $run_test_log 2>&1
+nthreads=${TEST_NTHREADS:-$(nproc)}
+$TEST_WRAPPER ./test_multithread_stress $nthreads 10 6  >> $run_test_log 2>&1
 if [ $? -ne 0 ]; then
     echo "test_multithread_stress failed."
     exit 1;

--- a/test/test_multithread_stress.c
+++ b/test/test_multithread_stress.c
@@ -267,7 +267,7 @@ int main(int argc, char **argv)
 
 	printf("Testing finished...\n");
 
-	printf("Total data: %ld GB\n", tsize/(1<<30));
+	printf("Total data: %.3f GB\n", ((double)tsize)/(1<<30));
 
 	return failed_thread;
 }


### PR DESCRIPTION
- Allow configurable number of threads (partially addresses #75)
- Fix total data statistic to properly print values smaller than 1 GB

More info on individual commit messages.