### PR TITLE
samples: Fix compiler errors

### DIFF
--- a/samples/Makefile
+++ b/samples/Makefile
@@ -4,7 +4,8 @@ SRC =
 INC = ../inc_nx
 LDFLAGS = -L../lib
 LDLIB = ../lib/libnxz.a -lpthread
-TESTS = gunzip_nx_test gzip_nxfht_test gzip_nxdht_test compdecomp_th
+TESTS = gunzip_nx_test gzip_nxfht_test gzip_nxdht_test compdecomp_th \
+	bad_irq_check rand_pfault_check
 NXFLAGS = #-DNXDBG  #-DNXDBG -DNXTIMER -DNX_MMAP
 
 all:

--- a/samples/compdecomp.c
+++ b/samples/compdecomp.c
@@ -96,7 +96,6 @@ int read_alloc_input_file(char *fname, char **buf, size_t *bufsize)
 int write_output_file(char *fname, char *buf, size_t bufsize)
 {
 	FILE *fp;
-	char *p;
 	size_t num_bytes;
 	if (NULL == (fp = fopen(fname, "w"))) {
 		perror(fname);
@@ -113,9 +112,8 @@ int write_output_file(char *fname, char *buf, size_t bufsize)
 
 int compress_file(int argc, char **argv)
 {
-	char *inbuf, *outbuf, *compbuf, *decompbuf;
-	char outname[1024];
-	size_t inlen, outlen;
+	char *inbuf, *compbuf, *decompbuf;
+	size_t inlen;
 	size_t compbuf_len, decompbuf_len;
 	uLongf compdata_len, decompdata_len;
 	int iterations = 100;

--- a/samples/makedata.c
+++ b/samples/makedata.c
@@ -16,10 +16,10 @@ typedef unsigned long ulong;
 int main(int argc, char **argv)
 {
 	size_t bufsz = OUTFILESZ;
-	size_t readsz, writesz;
+	size_t readsz;
 	char *buf;
 	size_t idx;
-	int seed;
+	int seed=0;
 
 	if (argc == 5 && strcmp(argv[1], "-s") == 0 && strcmp(argv[3], "-b") == 0) {
 		seed = atoi(argv[2]);
@@ -68,8 +68,8 @@ int main(int argc, char **argv)
 		}
 	}
 
-	writesz = fwrite(buf, 1, idx, stdout);
-		
+	fwrite(buf, 1, idx, stdout);
+
 	return 0;
 }
 


### PR DESCRIPTION
Some tests that are not part of the bench target were failing after
the -Werror change. This patch fixes them and adds the unsafe tests
to the ones being built with make bench.