### PR TITLE
Remove unnecessary checks during configuration processing

### DIFF
--- a/lib/nx_utils.c
+++ b/lib/nx_utils.c
@@ -99,8 +99,6 @@ static int find_cfg(char *key, struct nx_cfg_tab *cfg_table)
 
 	configs = cfg_table->configs;
 	for (i = 0; i < cfg_table->cfg_num; i++) {
-		if (!configs[i].key)
-			continue;
 		if (strcmp(key, configs[i].key) == 0)
 			return i;
 	}
@@ -138,9 +136,6 @@ static int set_cfg(struct nx_cfg_tab *cfg_table, char *key, char *val, int cnt)
 	} else
 		ret = 0;
 
-	if (!configs[cfg_cnt].key || !configs[cfg_cnt].val)
-		return -1;
-
 	memcpy(configs[cfg_cnt].key, trim_key, key_size);
 	if (trim_space(configs[cfg_cnt].val, MAX_CONFIG_LINE, val) < 0) {
 		/* val is all space, or lengh of val larger than MAX_CONFIG_LINE,
@@ -154,15 +149,14 @@ static int set_cfg(struct nx_cfg_tab *cfg_table, char *key, char *val, int cnt)
 int nx_dump_cfg(struct nx_cfg_tab *cfg_table, FILE *fp)
 {
 	int i;
-	char *key, *val;
+
 	if (!cfg_table || !fp)
 		return -1;
 
 	fprintf(fp, "nx-zlib config file ========\n");
 	for (i = 0; i < cfg_table->cfg_num; i++) {
-		key = (!cfg_table->configs[i].key) ? "NULL" : cfg_table->configs[i].key;
-		val = (!cfg_table->configs[i].val) ? "NULL" : cfg_table->configs[i].val;
-		fprintf(fp, "[%d]: %s = %s\n", i, key, val);
+		fprintf(fp, "[%d]: %s = %s\n", i, cfg_table->configs[i].key,
+			cfg_table->configs[i].val);
 	}
 
 	return 0;


### PR DESCRIPTION
GCC 12 (dev) started to complain that some NULL checks were not necessary as the
values could never be NULL. The warnings seem to be correct, so the checks have
been removed.

In find_cfg and nx_dump_cfg the loop iterates over a maximum of
cfg_table->cfg_num elements. As long as cfg_num is at most MAX_CONFIG_ITEM, we
are fine because cfg_table can hold that many elements, and key and val are
pointers to "static" arrays inside struct cfg_item.

In set_cfg, we access key and val of item at index cfg_cnt, which is guarded by
the function to be less than MAX_CONFIG_ITEM, so we are guaranteed to access
initialized data.

Tested with gcc 11.1.1 and gcc 12.0.0 (rev 5f0285418940).