### PR TITLE
Consolidate the Timebase register usage

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -22,4 +22,4 @@ ifeq "$(shell expr $(GCC_VER_MAIN) \>= 6)" "1"
     SFLAGS += -mcpu=power9
 endif
 
-CFLAGS = $(FLG) $(SFLAGS) $(ZLIB) #-DNXTIMER
+CFLAGS = $(FLG) $(SFLAGS) $(ZLIB)

--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -1239,8 +1239,7 @@ restart:
 				bytes_out = DEF_MAX_EXPANSION_LEN;
 
 			ticks_total = nx_wait_ticks(500, ticks_total, 0);
-			if (ticks_total > (timeout_pgfaults
-			    * __ppc_get_timebase_freq())) {
+			if (ticks_total > (timeout_pgfaults * nx_get_freq())) {
 				/* When page faults are too many oom_killer
 				 * should kill this process. */
 				rc = LIBNX_ERR_PAGEFLT;

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -317,7 +317,7 @@ int nx_inflate(z_streamp strm, int flush)
 		zlib_stats.inflate++;
 
 		zlib_stats.inflate_len += strm->avail_in;
-		t1 = get_nxtime_now();
+		t1 = nx_get_time();
 		pthread_mutex_unlock(&zlib_stats_mutex);
 	}
 
@@ -738,8 +738,8 @@ inf_return:
 	/* statistic */
 	if (nx_gzip_gather_statistics()) {
 		pthread_mutex_lock(&zlib_stats_mutex);
-		t2 = get_nxtime_now();
-		zlib_stats.inflate_time += get_nxtime_diff(t1,t2);
+		t2 = nx_get_time();
+		zlib_stats.inflate_time += nx_time_diff(t1, t2);
 		pthread_mutex_unlock(&zlib_stats_mutex);
 	}
 	return rc;
@@ -1213,8 +1213,7 @@ restart_nx:
 				target_sz = INF_MAX_EXPANSION_BYTES;
 
 			ticks_total = nx_wait_ticks(500, ticks_total, 0);
-			if (ticks_total > (timeout_pgfaults
-			    * __ppc_get_timebase_freq())) {
+			if (ticks_total > (timeout_pgfaults * nx_get_freq())) {
 			   /* TODO what to do when page faults are too many?
 			    * Kernel MM would have killed the process. */
 				prt_err("Cannot make progress; too many page");

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -441,31 +441,6 @@ inline void zlib_stats_inc(unsigned long *count)
         pthread_mutex_unlock(&zlib_stats_mutex);
 }
 
-static inline uint64_t get_nxtime_now(void)
-{
-	return __ppc_get_timebase();
-}
-
-static inline uint64_t get_nxtime_diff(uint64_t t1, uint64_t t2)
-{
-	if (t2 > t1) {
-		return t2-t1;
-	}else{
-		return (0xFFFFFFFFFFFFFFF-t1) + t2;
-	}
-}
-
-#ifndef __KERNEL__
-static inline double nxtime_to_us(uint64_t nxtime)
-{
-	uint64_t freq;
-
-	freq = __ppc_get_timebase_freq();
-	
-	return (double)(nxtime * 1000000 / freq) ;
-}
-#endif
-
 #ifndef ARRAY_SIZE
 #  define ARRAY_SIZE(a)	 (sizeof((a)) / sizeof((a)[0]))
 #endif

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -6,7 +6,7 @@ LDFLAGS = -L../lib
 LDLIB = ../lib/libnxz.a -lpthread
 TESTS = gunzip_nx_test gzip_nxfht_test gzip_nxdht_test compdecomp_th \
 	bad_irq_check rand_pfault_check
-NXFLAGS = #-DNXDBG  #-DNXDBG -DNXTIMER -DNX_MMAP
+NXFLAGS = #-DNXDBG  #-DNXDBG -DNX_MMAP
 
 all:
 

--- a/samples/gunzip_nx.c
+++ b/samples/gunzip_nx.c
@@ -63,15 +63,12 @@
 
 #define ASSERT(X) assert(X)
 
-#ifdef NXTIMER
 struct _nx_time_dbg {
 	uint64_t freq;
 	uint64_t sub1, sub2, subc;
 	uint64_t touch1, touch2;
 	uint64_t faultc, targetlenc, datalenc;
 } td;
-extern uint64_t dbgtimer;
-#endif
 
 #define NX_MIN(X,Y) (((X)<(Y))?(X):(Y))
 #define NX_MAX(X,Y) (((X)>(Y))?(X):(Y))
@@ -1206,7 +1203,6 @@ finish_state:
 			NX_CLK( fprintf(stderr, "touch  %ld ticks ", td.touch2)     );
 			NX_CLK( fprintf(stderr, "%g byte/s ", ((double)total_out*REPCNT)/((double)td.sub2/(double)td.freq)) );
 			NX_CLK( fprintf(stderr, "fault %ld target %ld datalen %ld\n", td.faultc, td.targetlenc, td.datalenc) );
-			/* NX_CLK( fprintf(stderr, "dbgtimer %ld\n", dbgtimer) ); */
 
 			if (cksum == cmdp->cpb.out_crc && isize == (uint32_t)(total_out % (1ULL<<32))) {
 				rc = 0;	goto ok1;

--- a/samples/gzip_nxdht.c
+++ b/samples/gzip_nxdht.c
@@ -78,15 +78,12 @@
 #endif
 #define NX_CHUNK_SZ  (1<<18)
 
-#ifdef NXTIMER
 struct _nx_time_dbg {
 	uint64_t freq;
 	uint64_t sub1, sub2, sub3, subc;
 	uint64_t touch1, touch2;
 	uint64_t fault;
 } td;
-extern uint64_t dbgtimer;
-#endif	
 
 static int compress_dht_sample(char *src, uint32_t srclen, char *dst, uint32_t dstlen,
 			       int with_count, nx_gzip_crb_cpb_t *cmdp, void *handle)

--- a/samples/gzip_nxfht.c
+++ b/samples/gzip_nxfht.c
@@ -67,15 +67,12 @@
 
 #define NX_MIN(X,Y) (((X)<(Y))?(X):(Y))
 
-#ifdef NXTIMER
 struct _nx_time_dbg {
 	uint64_t freq;
 	uint64_t sub1, sub2, sub3, subc;
 	uint64_t touch1, touch2;
 	uint64_t fault;
 } td;
-extern uint64_t dbgtimer;
-#endif	
 
 
 /* LZ counts returned in the user supplied nx_gzip_crb_cpb_t structure */

--- a/test/test_multithread_stress.c
+++ b/test/test_multithread_stress.c
@@ -144,7 +144,7 @@ static int run(const char* test)
 
 	pstats = get_info_by_tid(pthread_self());
 
-	index = __ppc_get_timebase() % (sizeof(buf_size_array)/sizeof(unsigned int));
+	index = nx_get_time() % (sizeof(buf_size_array)/sizeof(unsigned int));
 	src_len = buf_size_array[index];
 	compr_len = src_len*2;
 	uncompr_len = src_len*2;


### PR DESCRIPTION
- Remove macro NXTIMER.
- Remove unused dbgtimer.
- Replace all different functions with nx_get_time(), nx_get_freq() and
  nx_time_diff().
- Properly document these functions.
- Rewrite nx_get_freq() in order to cache the frequency information
  because reads of the Timebase register frequency are not fast.

This commit is intentionally leaving the selftest directory unchanged.