### PR TITLE
Add an automatic switch mode to gzip_selector

### DIFF
--- a/lib/nx_compress.c
+++ b/lib/nx_compress.c
@@ -99,8 +99,11 @@ int compress2(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen
 {
 	int rc=0;
 
-	if(nx_config.gzip_selector == GZIP_MIX){
-		rc = sw_compress2(dest, destLen, source, sourceLen, level);
+	if(nx_config.gzip_selector == GZIP_AUTO){
+		if(sourceLen <= COMPRESS_THRESHOLD)
+			rc = sw_compress2(dest, destLen, source, sourceLen, level);
+		else
+			rc = nx_compress2(dest, destLen, source, sourceLen, level);
 	}else if(nx_config.gzip_selector == GZIP_NX){
 		rc = nx_compress2(dest, destLen, source, sourceLen, level);
 	}else{

--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -2142,7 +2142,8 @@ int deflateInit2_(z_streamp strm, int level, int method, int windowBits,
 	zlib_stats_inc(&zlib_stats.deflateInit);
 
 	strm->state = NULL;
-	if(nx_config.gzip_selector == GZIP_MIX){
+	if(nx_config.gzip_selector == GZIP_AUTO ||
+	   nx_config.gzip_selector == GZIP_MIX){
 
 		/* call sw and nx initialization */
 		rc = sw_deflateInit2_(strm, level, method, windowBits, memLevel, strategy, version, stream_size);

--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -627,8 +627,6 @@ int nx_deflateInit2_(z_streamp strm, int level, int method, int windowBits,
 	if (s == NULL) return Z_MEM_ERROR;
 	memset(s, 0, sizeof(*s));
 
-	s->magic1     = MAGIC1;
-	s->magic2     = MAGIC2;
 	s->nxcmdp     = &s->nxcmd0;
 	s->wrap       = wrap;
 	s->windowBits = windowBits;

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -203,8 +203,6 @@ int nx_inflateInit2_(z_streamp strm, int windowBits, const char *version, int st
 	if (s == NULL) return Z_MEM_ERROR;
 	memset(s, 0, sizeof(*s));
 
-	s->magic1  = MAGIC1;
-	s->magic2  = MAGIC2;
 	s->zstrm   = strm;
 	s->nxcmdp  = &s->nxcmd0;
 	s->page_sz = nx_config.page_sz;

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -1935,7 +1935,9 @@ int inflateInit2_(z_streamp strm, int windowBits, const char *version, int strea
 	zlib_stats_inc(&zlib_stats.inflateInit);
 
 	strm->state = NULL;
-	if(nx_config.gzip_selector == GZIP_MIX){
+	if(nx_config.gzip_selector == GZIP_AUTO ||
+	   nx_config.gzip_selector == GZIP_MIX){
+		/* Call sw and nx initialization.  */
 		rc = sw_inflateInit2_(strm, windowBits, version, stream_size);
 		if(rc != Z_OK) return rc;
 
@@ -2034,7 +2036,6 @@ int inflate(z_streamp strm, int flush)
 		avail_out = strm->avail_out;
 		t1 = nx_get_time();
 	}
-
 
 	if (0 == has_nx_state(strm)){
 		prt_info("call sw_inflate,len=%d\n", strm->avail_in);

--- a/lib/nx_uncompr.c
+++ b/lib/nx_uncompr.c
@@ -77,8 +77,11 @@ int uncompress2(Bytef *dest, uLongf *destLen, const Bytef *source, uLong *source
 {
 	int rc;
 
-	if(nx_config.gzip_selector == GZIP_MIX){
-		rc = sw_uncompress2(dest, destLen, source, sourceLen);
+	if(nx_config.gzip_selector == GZIP_AUTO){
+		if(*sourceLen <= DECOMPRESS_THRESHOLD)
+			rc = sw_uncompress2(dest, destLen, source, sourceLen);
+		else
+			rc = nx_uncompress2(dest, destLen, source, sourceLen);
 	}else if(nx_config.gzip_selector == GZIP_NX){
 		rc = nx_uncompress2(dest, destLen, source, sourceLen);
 	}else{
@@ -99,8 +102,11 @@ int uncompress(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLe
 #else
 	int rc=0;
 
-	if(nx_config.gzip_selector == GZIP_MIX){
-		rc = sw_uncompress(dest, destLen, source, sourceLen);
+	if(nx_config.gzip_selector == GZIP_AUTO){
+		if(sourceLen <= DECOMPRESS_THRESHOLD)
+			rc = sw_uncompress(dest, destLen, source, sourceLen);
+		else
+			rc = nx_uncompress(dest, destLen, source, sourceLen);
 	}else if(nx_config.gzip_selector == GZIP_NX){
 		rc = nx_uncompress(dest, destLen, source, sourceLen);
 	}else{

--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -971,7 +971,7 @@ void nx_hw_init(void)
 	nx_config.dht = 0; /* default is literals only */
 	nx_config.nx_ratio = 100; /* default is 100% NX */
 	nx_config.strategy_override = 1; /* default is dynamic huffman */
-	nx_config.gzip_selector = GZIP_NX; /* default is to use NX only */
+	nx_config.gzip_selector = GZIP_AUTO; /* default to the automatic switch */
 
 	if (!cfg_file_s)
 		cfg_file_s = "./nx-zlib.conf";
@@ -1025,10 +1025,11 @@ void nx_hw_init(void)
 
 	if(type_selector != NULL){
 		nx_config.gzip_selector = str_to_num(type_selector);
-		prt("gzip_selector: %d (1-SW;2-NX;3/4-MIX)\n", nx_config.gzip_selector);
-		if(nx_config.gzip_selector == 0 || nx_config.gzip_selector > 4) {
-			prt("Unrecognized option, defaulting to NX.\n");
-			nx_config.gzip_selector = GZIP_NX;
+		prt("gzip_selector: %d (0-AUTO;1-SW;2-NX;3/4-MIX)\n", nx_config.gzip_selector);
+		/* check for misconfiguration */
+		if(nx_config.gzip_selector > 4) {
+			prt("Unrecognized option, defaulting to AUTO.\n");
+			nx_config.gzip_selector = GZIP_AUTO;
 		}
 	}
 

--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -1038,7 +1038,7 @@ void nx_hw_init(void)
 	if (nx_count == 0) {
 		nx_close_cfg(&cfg_tab);
 		prt_err("NX-gzip accelerators found: %d\n", nx_count);
-		nx_config.gzip_selector = GZIP_SW; /*fallback to use software zlib*/
+		return;
 	}
 
 	prt_info("%d NX GZIP Accelerator Found!\n",nx_count);
@@ -1147,7 +1147,9 @@ static void _nx_hwinit(void) __attribute__((constructor));
 static void _nx_hwinit(void)
 {
 	nx_hw_init();
-	sw_zlib_init();
+	/* Default to nx if zlib load failed.  */
+	if(sw_zlib_init() == Z_ERRNO)
+		nx_config.gzip_selector = GZIP_NX;
 }
 
 void nx_hw_done(void)

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -62,14 +62,14 @@
 #ifndef _NX_ZLIB_H
 #define _NX_ZLIB_H
 
-#define GZIP_SW		0x01 /* all ops to software gzip */
-#define GZIP_NX		0x02 /* all ops to nx gzip */
-#define GZIP_MIX	0x03 /* mix sw and nx with specific ratio*/
+#define GZIP_AUTO	0x00 /* use sw for small inputs and nx otherwise */
+#define GZIP_SW 	0x01 /* all ops to software gzip */
+#define GZIP_NX 	0x02 /* all ops to nx gzip */
+#define GZIP_MIX	0x03 /* mix sw and nx with specific ratio */
 #define GZIP_MIX2	0x04 /* deflate: nx ; inflate: sw */
 
-#define COMPRESS_THRESHOLD	(4*1024)
-#define DECOMPRESS_THRESHOLD	(4*1024)
-
+#define COMPRESS_THRESHOLD	(1024)
+#define DECOMPRESS_THRESHOLD	(1024)
 
 #define NX_MIN(X,Y) (((X)<(Y))?(X):(Y))
 #define NX_MAX(X,Y) (((X)>(Y))?(X):(Y))
@@ -331,6 +331,8 @@ static inline int use_nx_inflate(z_streamp strm)
 
 	/* #1 Threshold */
 	if(strm->avail_in <= DECOMPRESS_THRESHOLD) return 0;
+
+	if(nx_config.gzip_selector == GZIP_AUTO) return 1;
 
 	/* #2 Percentage */
 	rnd = __ppc_get_timebase();

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -62,11 +62,27 @@
 #ifndef _NX_ZLIB_H
 #define _NX_ZLIB_H
 
-#define GZIP_AUTO	0x00 /* use sw for small inputs and nx otherwise */
-#define GZIP_SW 	0x01 /* all ops to software gzip */
-#define GZIP_NX 	0x02 /* all ops to nx gzip */
-#define GZIP_MIX	0x03 /* mix sw and nx with specific ratio */
-#define GZIP_MIX2	0x04 /* deflate: nx ; inflate: sw */
+/*! \def GZIP_AUTO
+    \brief Use software compression/decompression for inputs smaller than a
+threshold and use NX otherwise.
+*/
+#define GZIP_AUTO	0x00
+/*! \def GZIP_SW
+    \brief Use software compression/decompression.
+*/
+#define GZIP_SW 	0x01
+/*! \def GZIP_NX
+    \brief Use NX compression/decompression.
+*/
+#define GZIP_NX 	0x02
+/*! \def GZIP_MIX
+    \brief Compress like GZIP_AUTO but mix software and NX with specific ratio for inputs bigger than the threshold, use software for decompression.
+*/
+#define GZIP_MIX	0x03
+/*! \def GZIP_MIX2
+    \brief Use NX to compress and software to decompress.
+*/
+#define GZIP_MIX2	0x04
 
 #define COMPRESS_THRESHOLD	(1024)
 #define DECOMPRESS_THRESHOLD	(1024)

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -166,20 +166,15 @@ typedef struct nx_dev_t *nx_devp_t;
 /* save recent header bytes for hcrc calculations */
 typedef struct ckbuf_t { char buf[128]; } ckbuf_t;
 
-#define MAGIC1 0x1234567812345678ull
-#define MAGIC2 0xfeedbeeffeedbeefull
-
 /* z_stream equivalent of NX hardware */
 typedef struct nx_stream_s {
         /* parameters for the supported functions */
-	uint64_t        magic1;
 	int             level;          /* compression level */
 	int             method;         /* must be Z_DEFLATED for zlib */
 	int             windowBits;     /* also encodes zlib/gzip/raw */
 
 	int             memLevel;       /* 1...9 (default=8) */
 	int             strategy;       /* force compression algorithm */
-	uint64_t        magic2;
 
 	/* stream data management */
 	unsigned char   *next_in;       /* next input byte */
@@ -318,7 +313,7 @@ static inline int has_nx_state(z_streamp strm)
 	nx_state = (struct nx_stream_s *)(strm->state);
 	if (nx_state == NULL) return 0;
 
-	return ((nx_state->magic1 == MAGIC1) && (nx_state->magic2 == MAGIC2));
+	return ((-1 <= nx_state->level) && (nx_state->level <= 9));
 }
 
 static inline int use_nx_inflate(z_streamp strm)

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -576,7 +576,7 @@ extern int dht_lookup(nx_gzip_crb_cpb_t *cmdp, int request, void *handle);
 extern void *dht_copy(void *handle);
 
 /* sw_zlib.c */
-extern void sw_zlib_init(void);
+extern int sw_zlib_init(void);
 extern void sw_zlib_close(void);
 extern const char *sw_zlibVersion(void);
 extern int sw_deflateInit_(z_streamp strm, int level, const char* version, int stream_size);

--- a/lib/sw_zlib.c
+++ b/lib/sw_zlib.c
@@ -282,14 +282,14 @@ uLong sw_compressBound(uLong sourceLen)
 /*
  * Open the zlib dl and Register APIs
  */
-void sw_zlib_init(void)
+int sw_zlib_init(void)
 {
 	char *error;
 
 	sw_handler = dlopen(ZLIB_PATH, RTLD_LAZY);
 	if(sw_handler == NULL) {
 		prt_err(" %s\n", dlerror());
-		return;
+		return Z_ERRNO;
 	}
 
 	register_sym(zlibVersion);
@@ -323,7 +323,7 @@ void sw_zlib_init(void)
 	register_sym(compress2);
 
 	prt_info("software zlib version:%s\n",sw_zlibVersion());
-	return;
+	return Z_OK;
 }
 
 /*

--- a/test/nx-zlib.conf
+++ b/test/nx-zlib.conf
@@ -37,7 +37,8 @@ logfile = ./nx.log
 # select if use software (zlib) and/or hardware (nx) compression.
 # 0 - Use nx unless the input is smaller than a threshold.
 # 1 - Use zlib. 2 - Use nx.
-# 3 - Mix zlib and nx with a specific ratio (nx_ratio_s).
+# 3 - Compress like 0 but mix zlib and nx with a specific ratio (nx_ratio_s) if
+# the input is greater than the threshold and use zlib to decompress.
 # 4 - Use nx to compress and zlib to decompress.
 # default: 0
 #nx_selector = 0

--- a/test/nx-zlib.conf
+++ b/test/nx-zlib.conf
@@ -35,11 +35,12 @@ logfile = ./nx.log
 #cache_threshold = 8192
 
 # select if use software (zlib) and/or hardware (nx) compression.
+# 0 - Use nx unless the input is smaller than a threshold.
 # 1 - Use zlib. 2 - Use nx.
 # 3 - Mix zlib and nx with a specific ratio (nx_ratio_s).
 # 4 - Use nx to compress and zlib to decompress.
-# default: 2
-#nx_selector = 2
+# default: 0
+#nx_selector = 0
 
 # select the ratio when mixing software and hardware compression.
 # range is from 0 to 100 (0% to 100% use of nx).

--- a/test/run_test.sh.in
+++ b/test/run_test.sh.in
@@ -21,17 +21,28 @@ run() {
     fi
 }
 
+run_test_stress() {
+    i=0
+    while [ $i -lt 5 ]; do
+        export NX_GZIP_TYPE_SELECTOR=$i
+        echo "Using mode $i: "
+        run ./test_stress
+        i=$((i+1))
+    done
+}
+
 @ABITEST@
 run ./test_deflate
 run ./test_inflate
 run ./test_inflatesyncpoint
-run ./test_stress
 run ./test_crc32
 run ./test_adler32
 run ./test_multithread_stress ${TEST_NTHREADS:-$(nproc)} 10 6
 run ./test_pid_reuse 2
-run ./test_zeroinput
 run ./test_buf_error
+export NX_GZIP_TYPE_SELECTOR=2
+run ./test_zeroinput
+run_test_stress
 echo "------------------------------"
 
 grep -E 'run_case|failed' $run_test_log | tee -a $run_test_report


### PR DESCRIPTION
Adds a mode that automatically switches between software and hardware
compression depending on the input size and make it the default mode.