### PR TITLE
Cache input data if engine can't consume it all

### DIFF
--- a/test/test_inflatesyncpoint.c
+++ b/test/test_inflatesyncpoint.c
@@ -81,6 +81,7 @@ int main()
 	assert(nx_inflate(&strm, Z_SYNC_FLUSH) == Z_OK);
 
 	/* 1 byte before the sync point */
+	assert(strm.avail_in == 0);
 	assert(nx_inflateSyncPoint(&strm) == 0);
 
 	strm.avail_in = 1;


### PR DESCRIPTION
The latest changes to how fifo_in is used on inflate, and the addition of
test_inflatesyncpoint triggered a bug in which nx_inflate_ would stay in a loop
without making any progress until hitting the loop_max count.

In that test, the first user call to inflate provides just enough data to make
the engine stop exactly 1 byte before a sync point [1]. Besides the first bits
of the literal block header, that 1 missing byte also contains the last bits of
the previous block, so the input given to the engine would be insufficient to
completely process the previous deflate block.

For that reason, after calling the engine (and processing SBFT, SUBC, etc)
avail_in would be 1, because the NX could not process the last byte entirely due
to missing block bits. In such case, avail_in and avail_out would still be
greater than zero near the end of nx_inflate_, so the function_ would try to
keep calling NX until avail_in was zero, but in this scenario it can't progress
any further without further input, triggering an "infinite" loop (actually
bounded by loop_max).

Now instead of trying to call the engine again, the leftover input is copied to
fifo_in and inflate returns, asking for more input from the user, avoiding the
useless loop.

[1] sync point - inside a literal block header, right before LEN field