### PR TITLE
Add configuration cache_threshold

### DIFF
--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -1637,7 +1637,7 @@ s2:
 	if (s->avail_out > 0 && s->used_out > 0)
 		goto s1;
 
-	if ( ((s->used_in + s->avail_in) <= nx_config.compress_threshold) && /* small input */
+	if ( ((s->used_in + s->avail_in) <= nx_config.cache_threshold) && /* small input */
 		(flush != Z_SYNC_FLUSH)    &&   /* not requesting flush */
 		(flush != Z_PARTIAL_FLUSH) &&
 		(flush != Z_FULL_FLUSH)    &&

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -893,7 +893,7 @@ static int copy_data_to_fifo_in(nx_streamp s) {
 	uint32_t free_space, read_sz;
 
 	if (s->fifo_in == NULL) {
-		s->len_in = nx_config.soft_copy_threshold * 2;
+		s->len_in = nx_config.cache_threshold * 2;
 		if (NULL == (s->fifo_in = nx_alloc_buffer(s->len_in, nx_config.page_sz, 0))) {
 			prt_err("nx_alloc_buffer for inflate fifo_in\n");
 			return Z_MEM_ERROR;
@@ -1020,7 +1020,7 @@ copy_fifo_out_to_next_out:
 	   by NX because it may refuse to start processing a stream if the input
 	   is not large enough.  */
 	if (s->avail_in > 0
-	    && (s->avail_in + s->used_in < nx_config.soft_copy_threshold)
+	    && (s->avail_in + s->used_in < nx_config.cache_threshold)
 	    && s->avail_out > 0
 	    && flush != Z_FINISH && flush != Z_SYNC_FLUSH) {
 		/* We haven't accumulated enough data. Cache any input data

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -124,7 +124,7 @@ struct nx_config_t {
 	uint32_t per_job_len;          /* less than suspend limit */
 	uint32_t strm_def_bufsz;
 	uint32_t soft_copy_threshold;  /* choose memcpy or hwcopy */
-	uint32_t compress_threshold;   /* collect as much input */
+	uint32_t cache_threshold; /** Cache input before processing */
 	int 	 deflate_fifo_in_len;
 	int 	 deflate_fifo_out_len;
 	int      window_max;

--- a/test/deflate/0.c
+++ b/test/deflate/0.c
@@ -1,7 +1,6 @@
 #include "../test_deflate.h"
 #include "../test_utils.h"
 
-/* The total src buffer > nx_compress_threshold (10*1024) but avail_in is 1 */
 static int run(unsigned int len, int digit, const char* test)
 {
 	Byte *src, *compr, *uncompr;

--- a/test/deflate/compress.c
+++ b/test/deflate/compress.c
@@ -84,15 +84,15 @@ err:
 }
 
 /* case prefix is 10-19 */
-/* The total src buffer < nx_compress_threshold (10*1024) */
 int run_case10()
 {
+	/* The total src buffer < default cache_threshold. */
 	return run(5*1024, 0, 0, __func__);
 }
 
-/* The total src buffer > nx_compress_threshold (10*1024) */
 int run_case11()
 {
+	/* The total src buffer > cache_threshold. */
 	return run(20*1024, 0, 0, __func__);
 }
 

--- a/test/deflate/perf.c
+++ b/test/deflate/perf.c
@@ -4,7 +4,6 @@
 #include <time.h>
 #include <pthread.h>
 
-/* The total src buffer > nx_compress_threshold (10*1024) but avail_in is 1 */
 static int run(unsigned int len, int step, const char* test)
 {
 	Byte *src, *compr, *uncompr;

--- a/test/deflate/random_buffer.c
+++ b/test/deflate/random_buffer.c
@@ -1,7 +1,6 @@
 #include "../test_deflate.h"
 #include "../test_utils.h"
 
-/* The total src buffer > nx_compress_threshold (10*1024) but avail_in is 1 */
 static int run(unsigned int len, int step, const char* test)
 {
 	Byte *src, *compr, *uncompr;
@@ -40,19 +39,20 @@ err:
 
 /* case prefix is 2 ~ 9 */
 
-/* The total src buffer < nx_compress_threshold (10*1024) and avail_in is 1 */
 int run_case2()
 {
+	/* The total src buffer < default cache_threshold and avail_in is 1. */
 	return run(5*1024, 1,  __func__);
 }
 
-/* The total src buffer < nx_compress_threshold (10*1024) and 1 < avail_in < total */
 int run_case3()
 {
+	/* The total src buffer < default cache_threshold and
+	   1 < avail_in < total. */
 	return run(5*1000, 100, __func__);
 }
 
-/* The total src buffer < nx_compress_threshold (10*1024) and 1 < avail_in < total
+/* The total src buffer < default cache_threshold and 1 < avail_in < total
  * but avail_in is not aligned with src_len
  * TODO: this is an error case
  */
@@ -62,27 +62,30 @@ int run_case3_1()
 	return 0;
 }
 
-/* The total src buffer < nx_compress_threshold (10*1024) and avail_in is total */
 int run_case4()
 {
+	/* The total src buffer < default cache_threshold and avail_in is
+	   total. */
 	return run(5*1024, 5*1024, __func__);
 }
 
-/* The total src buffer > nx_compress_threshold (10*1024) and avail_in is 1 */
 int run_case5()
 {
+	/* The total src buffer > default cache_threshold and avail_in is 1. */
 	return run(64*1024, 1, __func__);
 }
 
-/* The total src buffer > nx_compress_threshold (10*1024) and 1 < avail_in < 10*1024 */
 int run_case6()
 {
+	/* The total src buffer > default cache_threshold and
+	   1 < avail_in < 10*1024. */
 	return run(64*10000, 10000, __func__);
 }
 
-/* The total src buffer > nx_compress_threshold (10*1024) and avail_in > 10*1024 */
 int run_case7()
 {
+	/* The total src buffer > default cache_threshold and
+	   avail_in > 10*1024. */
 	return run(64*20000, 20000, __func__);
 }
 

--- a/test/deflate/z_finish.c
+++ b/test/deflate/z_finish.c
@@ -39,7 +39,6 @@ static int _test_nx_deflatef(Byte* src, unsigned int src_len, Byte* compr,
 	return TEST_OK;
 }
 
-/* The total src buffer > nx_compress_threshold (10*1024) but avail_in is 1 */
 static int run(unsigned int len, int step, const char* test)
 {
 	Byte *src, *compr, *uncompr;
@@ -76,16 +75,15 @@ err:
 }
 
 /* case prefix is 30 ~ 39 */
-
-/* The total src buffer < nx_compress_threshold (10*1024) */
 int run_case30()
 {
+	/* The total src buffer < default cache_threshold. */
 	return run(5*1024, 1,  __func__);
 }
 
-/* The total src buffer > nx_compress_threshold (10*1024) */
 int run_case31()
 {
+	/* The total src buffer > default cache_threshold. */
 	return run(64*1024, 1, __func__);
 }
 

--- a/test/nx-zlib.conf
+++ b/test/nx-zlib.conf
@@ -31,8 +31,11 @@ logfile = ./nx.log
 # default: 300
 #timeout_pgfaults = 300
 
-# amount of input data to buffer before sending to NX
+# Threshold to start using the copy/paste facility.
 #soft_copy_threshold = 1024
+
+# Amount of input data to cache before sending to NX.
+#cache_threshold = 8192
 
 # select if use software (zlib) and/or hardware (nx) compression.
 # 1 - Use zlib. 2 - Use nx.


### PR DESCRIPTION
cache_threshold indicates the amount of data that should be cached
from nx_deflate() and nx_inflate() before sending a request to NX.

This new configuration replaces compress_threshold that was used
only in nx_deflate().

After this change, soft_copy_threshold is used only to indicate if the
copy/paste facility should be used or if memcpy() is preferred.