### PR TITLE
Small code cleanup

### DIFF
--- a/test/deflate/hello.c
+++ b/test/deflate/hello.c
@@ -18,19 +18,16 @@ int run_case1()
 		return TEST_ERROR;
 	}
 
-	for (int i = 0; i < 30; i++) {
-		/* Reset comprLen. */
-		comprLen = 10000*sizeof(int);
-		if (_test_nx_deflate((Byte *)hello, len, compr, &comprLen, 1,
-				     NULL))
-			return TEST_ERROR;
-		if (_test_inflate(compr, comprLen, uncompr, uncomprLen,
-				  (Byte *) hello, len, 1, NULL))
-			return TEST_ERROR;
-		if (_test_nx_inflate(compr, comprLen, uncompr, uncomprLen,
-				     (Byte *) hello, len, 1, Z_NO_FLUSH, NULL))
-			return TEST_ERROR;
-	}
+	/* Reset comprLen. */
+	comprLen = 10000*sizeof(int);
+	if (_test_nx_deflate((Byte *)hello, len, compr, &comprLen, 1, NULL))
+		return TEST_ERROR;
+	if (_test_inflate(compr, comprLen, uncompr, uncomprLen,
+				(Byte *) hello, len, 1, NULL))
+		return TEST_ERROR;
+	if (_test_nx_inflate(compr, comprLen, uncompr, uncomprLen,
+				(Byte *) hello, len, 1, Z_NO_FLUSH, NULL))
+		return TEST_ERROR;
 
 	free(compr);
 	free(uncompr);


### PR DESCRIPTION
- Get rid of s3 label to make code cleaner
- Remove needless iterations in deflate_test:run_case1 