### PR TITLE
Add missing call to nx_inflateEnd on test_inflatesyncpoint

### DIFF
--- a/test/test_inflatesyncpoint.c
+++ b/test/test_inflatesyncpoint.c
@@ -119,6 +119,8 @@ int main()
 	strm.avail_out = uncompr_len - strm.total_out;
 	assert(nx_inflate(&strm, Z_FINISH) == Z_STREAM_END);
 
+	assert(nx_inflateEnd(&strm) == Z_OK);
+
 	if (compare_data(uncompr, src, src_len))
 		return TEST_ERROR;
 


### PR DESCRIPTION
test_inflatesyncpoint is failing the valgrind-check target because there is
allocated memory at the end of execution. This is easily fixed by calling
nx_inflateEnd before exiting the test.