### PR TITLE
Replace zlib function calls to alias functions

### DIFF
--- a/lib/nx_adler32.c
+++ b/lib/nx_adler32.c
@@ -176,36 +176,20 @@ unsigned long nx_adler32_combine(adler1, adler2, len2)
 /* ========================================================================= */
 
 #ifdef ZLIB_API
-unsigned long adler32_combine(adler1, adler2, len2)
-    unsigned long adler1;
-    unsigned long adler2;
-    z_off_t len2;
-{
-    return nx_adler32_combine(adler1, adler2, len2);
-}
 
-unsigned long adler32_combine64(adler1, adler2, len2)
-    unsigned long adler1;
-    unsigned long adler2;
-    z_off64_t len2;
-{
-    return nx_adler32_combine(adler1, adler2, len2);
-}
+unsigned long adler32_combine(unsigned long adler1, unsigned long adler2,
+			      z_off_t len2)
+	      __attribute__((alias("nx_adler32_combine")));
 
-unsigned long adler32(adler, buf, len)
-    unsigned long adler;
-    const char *buf;
-    unsigned int len;
-{
-    return nx_adler32_z(adler, buf, len);
-}
+unsigned long adler32_combine64(unsigned long adler1, unsigned long adler2,
+			      z_off_t len2)
+	      __attribute__((alias("nx_adler32_combine")));
 
-unsigned long adler32_z(adler, buf, len)
-    unsigned long adler;
-    const char *buf;
-    z_size_t len;
-{
-    return nx_adler32_z(adler, buf, len);
-}
+unsigned long adler32(unsigned long adler, const char * buf, unsigned int len)
+	      __attribute__((alias("nx_adler32_z")));
+
+unsigned long adler32_z(unsigned long adler, const char * buf, z_size_t len)
+	      __attribute__((alias("nx_adler32_z")));
+
 #endif
 

--- a/lib/nx_crc.c
+++ b/lib/nx_crc.c
@@ -471,20 +471,11 @@ unsigned long crc32(crc, buf, len)
     return crc32_ppc(crc, (unsigned char *)buf, len);
 }
 
-uLong crc32_combine(crc1, crc2, len2)
-    uLong crc1;
-    uLong crc2;
-    uint64_t len2;
-{
-    return nx_crc32_combine(crc1, crc2, len2);
-}
+uLong crc32_combine(uLong crc1, uLong crc2, uint64_t len2)
+      __attribute__((alias("nx_crc32_combine")));
 
-uLong crc32_combine64(crc1, crc2, len2)
-    uLong crc1;
-    uLong crc2;
-    uint64_t len2;
-{
-    return nx_crc32_combine64(crc1, crc2, len2);
-}
+uLong crc32_combine64(uLong crc1, uLong crc2, uint64_t len2)
+      __attribute__((alias("nx_crc32_combine64")));
+
 #endif
 


### PR DESCRIPTION
Replace the wrapper functions from zlib to libnxz for the
corresponding symbols by using alias functions in order
to remove the unnecessary calls.

I didn't change inflateSyncPoint because I'll change it on #93