### PR TITLE
Fix CFLAGS usage after migrating to GNU Autoconf

### DIFF
--- a/configure
+++ b/configure
@@ -2450,7 +2450,7 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
 
-: ${CFLAGS="-O3 -Wall -Werror -fPIC"}
+: ${CFLAGS="-O3 -Wall -Werror -g"}
 
 # Checks for programs.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking target system type" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AC_CONFIG_MACRO_DIR([m4])
 # Defines host_cpu, host_vendor, and host_os variables.
 AC_CANONICAL_HOST
 
-: ${CFLAGS="-O3 -Wall -Werror -fPIC"}
+: ${CFLAGS="-O3 -Wall -Werror -g"}
 
 # Checks for programs.
 AC_CHECK_TARGET_TOOL([AR], [ar], [:])

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -11,6 +11,9 @@ SHAREDLIB = $(PACKAGENAME).so.$(VERSION)
 LIBLINK = $(PACKAGENAME).so
 
 CFLAGS += -I../inc_nx
+# Generate all object files as PIC because we use them both in the static and
+# shared libraries.
+CFLAGS += -fPIC
 
 all: $(OBJS) $(STATICLIB) $(SHAREDLIB)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,5 @@
 include ../config.mk
 
-CFLAGS = $(FLG) $(SFLAGS)
 INC = -I../lib -I../inc_nx
 LIB = -L../lib -L/usr/lib/
 


### PR DESCRIPTION
1. Enforce -fPIC usage under lib/.
2. Enable -g by default.
3. Stop overwriting CFLAGS in test/.

I intentionally left a redefinition of CFLAGS from `selftest/Makefile` because it doesn't include `config.mk`.