### PR TITLE
Mark some variables as volatile

### DIFF
--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -885,7 +885,8 @@ static void nx_compress_block_get_cpb(nx_streamp s, int fc)
 /* updates stream offsets and also sets the block final bit */
 static int  nx_compress_block_update_offsets(nx_streamp s, int fc)
 {
-	uint32_t copy_bytes, histbytes, overflow;
+	uint32_t copy_bytes, overflow;
+	volatile uint32_t histbytes;
 
 	prt_info("%s:%d fc %d\n", __FUNCTION__, __LINE__, fc);
 
@@ -1463,7 +1464,7 @@ static inline void nx_compress_update_checksum(nx_streamp s, int combine)
 		   checksums explicitly here (2) Do not "combine" the
 		   very first wrap output checksum because nx already
 		   assumes that the checksums are initialized */
-		uint32_t cksum;
+		volatile uint32_t cksum;
 		cksum = get32(nxcmdp->cpb, out_adler);
 		s->adler32 = nx_adler32_combine(s->adler32, cksum, s->spbc);
 

--- a/lib/nx_dht.c
+++ b/lib/nx_dht.c
@@ -479,7 +479,7 @@ static int dht_search_cache(nx_gzip_crb_cpb_t *cmdp, dht_tab_t *dht_tab, top_sym
 
 static int dht_use_last(nx_gzip_crb_cpb_t *cmdp, dht_tab_t *dht_tab)
 {
-	long source_bytes;
+	volatile long source_bytes;
 	uint32_t fc, histlen;
 	dht_entry_t *dht_entry = dht_atomic_load( &dht_tab->last_used_entry );
 

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -935,14 +935,16 @@ static int copy_data_to_fifo_in(nx_streamp s) {
 static int nx_inflate_(nx_streamp s, int flush)
 {
 	/* queuing, file ops, byte counting */
-	uint32_t write_sz, source_sz, target_sz;
+	uint32_t write_sz, target_sz;
+	volatile uint32_t source_sz;
 	long loop_cnt = 0, loop_max = 0xffff;
 
 	/* inflate benefits from large jobs; memcopies must be amortized */
 	uint32_t inflate_per_job_len = 64 * nx_config.per_job_len;
 
 	/* nx hardware */
-	uint32_t sfbt = 0, subc = 0, spbc, tpbc, nx_ce, fc;
+	volatile uint32_t sfbt = 0, subc = 0, spbc, tpbc, nx_ce;
+	uint32_t fc;
 
 	nx_gzip_crb_cpb_t *cmdp = s->nxcmdp;
 	nx_dde_t *ddl_in = s->ddl_in;
@@ -1391,7 +1393,7 @@ ok_cc3:
 	*/
 	switch (sfbt) {
 		char* last_byte;
-		int dhtlen;
+		volatile int dhtlen;
 
 	case 0b0000: /* Deflate final EOB received */
 

--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -269,8 +269,7 @@ void nx_free_buffer(void *buf, uint32_t len, int unlock)
 */
 int nx_append_dde(nx_dde_t *ddl, void *addr, uint32_t len)
 {
-	uint32_t ddecnt;
-	uint32_t bytes;
+	volatile uint32_t ddecnt, bytes;
 
 	if (addr == NULL || len == 0) {
 		return 0;
@@ -334,10 +333,9 @@ int nx_append_dde(nx_dde_t *ddl, void *addr, uint32_t len)
 */
 int nx_touch_pages_dde(nx_dde_t *ddep, long buf_sz, long page_sz, int wr)
 {
-	uint32_t indirect_count;
-	uint32_t buf_len;
+	volatile uint32_t indirect_count, buf_len;
 	long total;
-	uint64_t buf_addr;
+	volatile uint64_t buf_addr;
 	nx_dde_t *dde_list;
 	int i;
 
@@ -399,9 +397,9 @@ int nx_touch_pages_dde(nx_dde_t *ddep, long buf_sz, long page_sz, int wr)
 void nx_print_dde(nx_dde_t *ddep, const char *msg)
 {
 	uint32_t indirect_count;
-	uint32_t buf_len;
-	uint64_t buf_addr;
-	nx_dde_t *dde_list;
+	volatile uint32_t buf_len;
+	volatile uint64_t buf_addr;
+	volatile nx_dde_t *dde_list;
 	int i;
 
 	ASSERT(!!ddep);
@@ -448,7 +446,7 @@ void nx_print_dde(nx_dde_t *ddep, const char *msg)
  */
 int nx_submit_job(nx_dde_t *src, nx_dde_t *dst, nx_gzip_crb_cpb_t *cmdp, void *handle)
 {
-	int cc;
+	volatile int cc;
 	uint64_t csbaddr;
 
 	memset( (void *)&cmdp->crb.csb, 0, sizeof(cmdp->crb.csb) );
@@ -1185,11 +1183,12 @@ static void _nx_hwdone(void)
    checksum values only because GZIP_FC_WRAP doesn't take any initial
    values.
 */
-static inline int __nx_copy(char *dst, char *src, uint32_t len, uint32_t *crc, uint32_t *adler, nx_devp_t nxdevp)
+static inline int __nx_copy(char *dst, char *src, uint32_t len, uint32_t *_crc, uint32_t *_adler, nx_devp_t nxdevp)
 {
 	nx_gzip_crb_cpb_t cmd;
 	int cc, timeout_pgfaults;
 	uint64_t ticks_total = 0;
+	volatile uint32_t *crc = _crc, *adler = _adler;
 
 	timeout_pgfaults = nx_config.timeout_pgfaults;
 

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -204,8 +204,8 @@ typedef struct nx_stream_s {
 	/* private area */
 	uint32_t        adler;          /* one of adler32 or crc32 */
 
-	uint32_t        adler32;        /* machine generated */
-	uint32_t        crc32;          /* checksums of bytes
+	volatile uint32_t        adler32;        /* machine generated */
+	volatile uint32_t        crc32;          /* checksums of bytes
                                          * compressed then written to
                                          * the stream out. note that
                                          * this interpretation is
@@ -285,13 +285,13 @@ typedef struct nx_stream_s {
 	uint32_t        nx_ce;          /* completion extension Fig.6-7 */
 	int             z_rc;           /* libz return codes */
 
-	uint32_t        spbc;
+	volatile uint32_t        spbc;
 	/** \brief Target Processed Byte Count
 	 * \details Amount of target data bytes an accelerator has written in
 	 * processing this CRB.
 	 */
-	uint32_t        tpbc;
-	uint32_t        tebc;
+	volatile uint32_t        tpbc;
+	volatile uint32_t        tebc;
 
 	/* nx commands */
 	int             flush;


### PR DESCRIPTION
~~test_multithread_stress has been failing when run under valgrind if libnxz is
compiled with GCC 10 and optimization levels higher than -O1:~~

~~test_multithread_stress: nx_deflate.c:990: nx_compress_block_update_offsets:
Assertion `overflow <= s->len_out/2' failed.~~

~~This issue is not present on more recent versions of GCC, and is highly
sensitive to changes in the code, which makes it very hard to debug, so we don't
have a root cause so far. Fortunately, disabling inlining for
nx_compress_block_update_offsets is enough to avoid the issue for now without
much impact.~~

~~Tested-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>
Signed-off-by: Matheus Castanho <msc@linux.ibm.com>~~

**EDIT**: I updated this PR to use @abalib's suggestion of using volatile.

We use macros like getnn, get[p]32 and get[p]64 to read values from addresses
written by the NX engine. Since changes to these addresses are outside of the
compiler's scope, it shouldn't be totally free to apply optimizations on the
variables used to read from these addresses. So mark any such variables as
volatile to avoid problems.

We have recently faced one of such issues: test_multithread_stress has been
failing when run under valgrind if libnxz is compiled with GCC 10 and
optimization levels higher than -O1:

test_multithread_stress: nx_deflate.c:990: nx_compress_block_update_offsets:
Assertion `overflow <= s->len_out/2' failed.

It is fixed by this commit.

Fixes #86 