### PR TITLE
Skip test_abi if abidiff is not available

### DIFF
--- a/configure
+++ b/configure
@@ -657,6 +657,7 @@ target_os
 target_vendor
 target_cpu
 target
+ABITEST
 ABIDIFF
 host_os
 host_vendor
@@ -2349,6 +2350,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 ac_config_files="$ac_config_files config.mk oct/config.mk"
 
+ac_config_files="$ac_config_files test/run_test.sh"
+
 
 # TODO: Leave this commented out while Automake is not being used.
 #AC_CONFIG_HEADERS([config.h])
@@ -2498,8 +2501,13 @@ $as_echo "no" >&6; }
 fi
 
 
-if test "x$ABIDIFF" = xno; then :
-  as_fn_error $? "Please install abidiff (tool from libabigail)." "$LINENO" 5
+if test "x$ABIDIFF" != xno; then :
+  ABITEST="run ./test_abi ../lib/libnxz.so"
+
+else
+  ABITEST='# ABI test skipped because abidiff is not available'
+
+
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking target system type" >&5
 $as_echo_n "checking target system type... " >&6; }
@@ -7153,6 +7161,7 @@ do
   case $ac_config_target in
     "config.mk") CONFIG_FILES="$CONFIG_FILES config.mk" ;;
     "oct/config.mk") CONFIG_FILES="$CONFIG_FILES oct/config.mk" ;;
+    "test/run_test.sh") CONFIG_FILES="$CONFIG_FILES test/run_test.sh" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac
@@ -7571,6 +7580,11 @@ which seems to be undefined.  Please make sure it is defined" >&2;}
 
   esac
 
+
+  case $ac_file$ac_mode in
+    "test/run_test.sh":F) chmod +x test/run_test.sh ;;
+
+  esac
 done # for ac_tag
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ AC_INIT([libnxz],[0.62],[https://github.com/libnxz/power-gzip])
 
 AC_CONFIG_SRCDIR([lib/nx_zlib.c])
 AC_CONFIG_FILES([config.mk oct/config.mk])
+AC_CONFIG_FILES([test/run_test.sh], [chmod +x test/run_test.sh])
 AC_CONFIG_MACRO_DIR([m4])
 # TODO: Leave this commented out while Automake is not being used.
 #AC_CONFIG_HEADERS([config.h])
@@ -22,8 +23,10 @@ AC_CANONICAL_HOST
 
 # Checks for programs.
 AC_CHECK_PROG(ABIDIFF, abidiff, abidiff, no)
-AS_IF([test "x$ABIDIFF" = xno],
-      [AC_MSG_ERROR([Please install abidiff (tool from libabigail).])])
+AS_IF([test "x$ABIDIFF" != xno],
+      [AC_SUBST(ABITEST,"run ./test_abi ../lib/libnxz.so")],
+      [AC_SUBST(ABITEST,'# ABI test skipped because abidiff is not available'
+)])
 AC_CHECK_TARGET_TOOL([AR], [ar], [:])
 AC_PROG_AWK
 AC_PROG_CC

--- a/test/run_test.sh.in
+++ b/test/run_test.sh.in
@@ -21,7 +21,7 @@ run() {
     fi
 }
 
-run ./test_abi ../lib/libnxz.so
+@ABITEST@
 run ./test_deflate
 run ./test_inflate
 run ./test_inflatesyncpoint


### PR DESCRIPTION
Failing to build if abidiff is not available is too strict. In that case we
should still be able to build the lib and run all other tests. So only skip
test_abi instead.

Signed-off-by: Matheus Castanho <msc@linux.ibm.com>