### PR TITLE
Enable builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: c
+
+matrix:
+  include:
+    - name: "linux-ppc64le-gcc-9"
+      os: linux
+      dist: bionic
+      arch: ppc64le
+      compiler: gcc-9
+      env:
+        - CXX="g++-9"
+        - PKG_CC="gcc-9 g++-9"
+    - name: "linux-ppc64le-gcc-10"
+      os: linux
+      dist: bionic
+      arch: ppc64le
+      compiler: gcc-10
+      env:
+        - CXX="g++-10"
+        - PKG_CC="gcc-10 g++-10"
+    - name: "linux-ppc64le-gcc-11"
+      os: linux
+      dist: focal
+      arch: ppc64le
+      compiler: gcc-11
+      env:
+        - CXX="g++-11"
+        - PKG_CC="gcc-11 g++-11"
+
+before_install:
+  - sudo add-apt-repository universe
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update
+  - travis_wait 5 sudo apt-get -y install ${PKG_CC} doxygen graphviz
+
+script:
+  - mkdir $(pwd)/install
+  - ./configure --prefix=$(pwd)/install
+  - make -j$(nproc)
+  - make -j$(nproc) -C test build-TESTS
+  - make -j$(nproc) bench
+  - make -j$(nproc) -C selftest all
+  - make -j$(nproc) install

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -82,3 +82,5 @@ regen-abi:
 	abidw $(ABIDW_FLAGS) ../lib/.libs/libnxz.so > $(srcdir)/libnxz.abi
 	@echo "To regenerate libz.abi, build zlib or find system's libz.so and do:"
 	@echo "    abidw $(ABIDW_FLAGS) /path/to/libz.so > libz.abi"
+
+build-TESTS: $(check_PROGRAMS) $(check_SCRIPTS)

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -1418,6 +1418,8 @@ regen-abi:
 	@echo "To regenerate libz.abi, build zlib or find system's libz.so and do:"
 	@echo "    abidw $(ABIDW_FLAGS) /path/to/libz.so > libz.abi"
 
+build-TESTS: $(check_PROGRAMS) $(check_SCRIPTS)
+
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.
 .NOEXPORT:


### PR DESCRIPTION
Travis CI does not provide access to the NX GZIP engine, making it hard
to run tests.  However it still allows to build all the files and report
errors with different compiler versions as well as static analyzers.

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>