### PR TITLE
Fix valgrind-check when building from the source directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,7 @@ doc_target = doc
 endif DX_COND_doc
 
 VALGRIND_FLAGS="--leak-check=full \
-		--suppressions=$(top_srcdir)/test/valgrind.supp \
+		--suppressions=$(abs_top_srcdir)/test/valgrind.supp \
 		--error-exitcode=1"
 
 all: $(SUBDIRS) $(doc_target)

--- a/Makefile.in
+++ b/Makefile.in
@@ -420,7 +420,7 @@ dist_doc_DATA = licenses/APACHE-2.0.txt licenses/gpl-2.0.txt
 include_HEADERS = libnxz.h
 @DX_COND_doc_TRUE@doc_target = doc
 VALGRIND_FLAGS = "--leak-check=full \
-		--suppressions=$(top_srcdir)/test/valgrind.supp \
+		--suppressions=$(abs_top_srcdir)/test/valgrind.supp \
 		--error-exitcode=1"
 
 @DX_COND_doc_TRUE@MOSTLYCLEANFILES = $(DX_CLEANFILES)


### PR DESCRIPTION
Use a variable that is guaranteed to have an absolute
path (abs_top_srcdir) instead of top_srcdir, which may have a relative
path when the build directory is identical to the source directory.