### PR TITLE
Readd magic numbers to libnxz internal state

### DIFF
--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -627,6 +627,7 @@ int nx_deflateInit2_(z_streamp strm, int level, int method, int windowBits,
 	if (s == NULL) return Z_MEM_ERROR;
 	memset(s, 0, sizeof(*s));
 
+	s->magic1     = MAGIC1;
 	s->nxcmdp     = &s->nxcmd0;
 	s->wrap       = wrap;
 	s->windowBits = windowBits;

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -203,6 +203,7 @@ int nx_inflateInit2_(z_streamp strm, int windowBits, const char *version, int st
 	if (s == NULL) return Z_MEM_ERROR;
 	memset(s, 0, sizeof(*s));
 
+	s->magic1  = MAGIC1;
 	s->zstrm   = strm;
 	s->nxcmdp  = &s->nxcmd0;
 	s->page_sz = nx_config.page_sz;

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -182,9 +182,12 @@ typedef struct nx_dev_t *nx_devp_t;
 /* save recent header bytes for hcrc calculations */
 typedef struct ckbuf_t { char buf[128]; } ckbuf_t;
 
+#define MAGIC1 0x1234567887654321ull
+
 /* z_stream equivalent of NX hardware */
 typedef struct nx_stream_s {
         /* parameters for the supported functions */
+	uint64_t        magic1;
 	int             level;          /* compression level */
 	int             method;         /* must be Z_DEFLATED for zlib */
 	int             windowBits;     /* also encodes zlib/gzip/raw */
@@ -329,7 +332,7 @@ static inline int has_nx_state(z_streamp strm)
 	nx_state = (struct nx_stream_s *)(strm->state);
 	if (nx_state == NULL) return 0;
 
-	return ((-1 <= nx_state->level) && (nx_state->level <= 9));
+	return (nx_state->magic1 == MAGIC1);
 }
 
 static inline int use_nx_inflate(z_streamp strm)


### PR DESCRIPTION
Commit facbbf4a4192f8c06f8772cf10b495650c9c0c89 removed the magic numbers used
to distinguish between libnxz's and zlib's internal states and started relying
on comparing just the first field, which should always be different. Although
this is true for zlib 1.2.11 (latest), it's not for zlib 1.2.7 (used on
RHEL7). The strm pointer was only added on version 1.2.9. Before that, the first
field was the inflate mode, which may be 0 right after initialization. At that
point has_nx_state is not able to properly distinguish between zlib and libnxz
internal states, causing issues when software zlib is to be used.

This is a partial revert of commit facbbf4a4192f8c06f8772cf10b495650c9c0c89 with
a single magic number being used.

Fixes test_deflate and test_inflate running on a RHEL7 container:
$ make check TESTS='test_inflate.sw test_inflate.mix test_inflate.mix2 test_inflate.auto test_inflate.nx'
...
PASS: test_inflate.sw
PASS: test_inflate.mix
PASS: test_inflate.mix2
PASS: test_inflate.auto
PASS: test_inflate.nx

$ make check TESTS='test_deflate.sw test_deflate.mix test_deflate.mix2 test_deflate.auto test_deflate.nx'
...
PASS: test_deflate.sw
PASS: test_deflate.mix
PASS: test_deflate.mix2
PASS: test_deflate.auto
PASS: test_deflate.nx