### PR TITLE
Don't run nx_hw_init more than once

### DIFF
--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -582,8 +582,6 @@ int nx_deflateInit2_(z_streamp strm, int level, int method, int windowBits,
 
 	if (strm == Z_NULL) return Z_STREAM_ERROR;
 
-	nx_hw_init();
-
 	strm->msg = Z_NULL;
 
 	strm->total_in = 0;

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -189,8 +189,6 @@ int nx_inflateInit2_(z_streamp strm, int windowBits, const char *version, int st
 
 	if (strm == Z_NULL) return Z_STREAM_ERROR;
 
-	nx_hw_init();
-
 	strm->msg = Z_NULL; /* in case we return an error */
 
 	h = nx_open(-1); /* if want to pick specific NX device, set env NX_GZIP_DEV_NUM */


### PR DESCRIPTION
nx_hw_init takes care of several jobs that must only be run once, like
initializing the log file and the mutexes used in the library. Besides as a
library constructor, it was also being called on deflateInit2 and inflateInit2,
which cause undefined behavior by re-initializing the mutexes.