### PR TITLE
Implement some gz functions

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -20,6 +20,7 @@ libnxz_la_SOURCES = \
 		    nx_dht.c \
 		    nx_dhtgen.c \
 		    nx_dht_builtin.c \
+		    nx_gzlib.c \
 		    nx_inflate.c \
 		    nx_uncompr.c \
 		    nx_utils.c \

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -137,8 +137,8 @@ am__DEPENDENCIES_1 =
 libnxz_la_DEPENDENCIES = $(am__DEPENDENCIES_1)
 am_libnxz_la_OBJECTS = crc32_ppc.lo crc32_power.lo gzip_vas.lo \
 	nx_adler32.lo nx_compress.lo nx_crc.lo nx_deflate.lo nx_dht.lo \
-	nx_dhtgen.lo nx_dht_builtin.lo nx_inflate.lo nx_uncompr.lo \
-	nx_utils.lo nx_zlib.lo sw_zlib.lo
+	nx_dhtgen.lo nx_dht_builtin.lo nx_gzlib.lo nx_inflate.lo \
+	nx_uncompr.lo nx_utils.lo nx_zlib.lo sw_zlib.lo
 libnxz_la_OBJECTS = $(am_libnxz_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -167,9 +167,10 @@ am__depfiles_remade = ./$(DEPDIR)/crc32_power.Plo \
 	./$(DEPDIR)/nx_adler32.Plo ./$(DEPDIR)/nx_compress.Plo \
 	./$(DEPDIR)/nx_crc.Plo ./$(DEPDIR)/nx_deflate.Plo \
 	./$(DEPDIR)/nx_dht.Plo ./$(DEPDIR)/nx_dht_builtin.Plo \
-	./$(DEPDIR)/nx_dhtgen.Plo ./$(DEPDIR)/nx_inflate.Plo \
-	./$(DEPDIR)/nx_uncompr.Plo ./$(DEPDIR)/nx_utils.Plo \
-	./$(DEPDIR)/nx_zlib.Plo ./$(DEPDIR)/sw_zlib.Plo
+	./$(DEPDIR)/nx_dhtgen.Plo ./$(DEPDIR)/nx_gzlib.Plo \
+	./$(DEPDIR)/nx_inflate.Plo ./$(DEPDIR)/nx_uncompr.Plo \
+	./$(DEPDIR)/nx_utils.Plo ./$(DEPDIR)/nx_zlib.Plo \
+	./$(DEPDIR)/sw_zlib.Plo
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
@@ -384,6 +385,7 @@ libnxz_la_SOURCES = \
 		    nx_dht.c \
 		    nx_dhtgen.c \
 		    nx_dht_builtin.c \
+		    nx_gzlib.c \
 		    nx_inflate.c \
 		    nx_uncompr.c \
 		    nx_utils.c \
@@ -484,6 +486,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_dht.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_dht_builtin.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_dhtgen.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_gzlib.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_inflate.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_uncompr.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_utils.Plo@am__quote@ # am--include-marker
@@ -664,6 +667,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/nx_dht.Plo
 	-rm -f ./$(DEPDIR)/nx_dht_builtin.Plo
 	-rm -f ./$(DEPDIR)/nx_dhtgen.Plo
+	-rm -f ./$(DEPDIR)/nx_gzlib.Plo
 	-rm -f ./$(DEPDIR)/nx_inflate.Plo
 	-rm -f ./$(DEPDIR)/nx_uncompr.Plo
 	-rm -f ./$(DEPDIR)/nx_utils.Plo
@@ -724,6 +728,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/nx_dht.Plo
 	-rm -f ./$(DEPDIR)/nx_dht_builtin.Plo
 	-rm -f ./$(DEPDIR)/nx_dhtgen.Plo
+	-rm -f ./$(DEPDIR)/nx_gzlib.Plo
 	-rm -f ./$(DEPDIR)/nx_inflate.Plo
 	-rm -f ./$(DEPDIR)/nx_uncompr.Plo
 	-rm -f ./$(DEPDIR)/nx_utils.Plo

--- a/lib/Versions
+++ b/lib/Versions
@@ -64,6 +64,7 @@ LIBNXZ_0.64.0 {
     nx_gzclose;
     nx_gzopen;
     nx_gzdopen;
+    nx_gzread;
     nx_gzwrite;
 } LIBNXZ_0.63.0;
 

--- a/lib/Versions
+++ b/lib/Versions
@@ -60,6 +60,12 @@ LIBNXZ_0.63.0 {
     nx_inflateSyncPoint;
 } LIBNXZ_0.61.0;
 
+LIBNXZ_0.64.0 {
+    nx_gzclose;
+    nx_gzopen;
+    nx_gzdopen;
+} LIBNXZ_0.63.0;
+
 ZLIB_1.2.0 {
     compressBound;
     deflateBound;

--- a/lib/Versions
+++ b/lib/Versions
@@ -64,6 +64,7 @@ LIBNXZ_0.64.0 {
     nx_gzclose;
     nx_gzopen;
     nx_gzdopen;
+    nx_gzwrite;
 } LIBNXZ_0.63.0;
 
 ZLIB_1.2.0 {

--- a/lib/nx_gzlib.c
+++ b/lib/nx_gzlib.c
@@ -1,0 +1,171 @@
+/* nx_gzlib.c -- implement gz* functions
+ *
+ * NX-GZIP compression accelerator user library
+ * implementing zlib compression library interfaces
+ *
+ * Copyright (C) IBM Corporation, 2022
+ *
+ * Licenses for GPLv2 and Apache v2.0:
+ *
+ * GPLv2:
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ *
+ * Apache v2.0:
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "nx_zlib.h"
+
+#define DEF_MEM_LEVEL 8
+#define MAX_LEN 4096
+
+gzFile nx_gzopen_(const char* path, int fd, const char *mode);
+
+typedef struct gz_state {
+	gzFile gz;
+	int fd;
+	FILE *fp;
+	int err;
+	z_stream strm;
+	bool deflate;
+} *gz_statep;
+
+int nx_gzclose(gzFile file)
+{
+	gz_statep state = (gz_statep) file;
+	z_streamp stream = &(state->strm);
+	int ret;
+	unsigned char* next_out;
+
+	if (file == NULL){
+		errno = EINVAL;
+		return Z_STREAM_ERROR;
+	}
+
+	next_out = malloc(sizeof(char)*MAX_LEN);
+	if (next_out == NULL)
+		return Z_MEM_ERROR;
+
+	if (state->deflate) {
+		/* Finish the stream.  */
+		stream->next_in = Z_NULL;
+		stream->avail_in = 0;
+		do {
+			stream->next_out = next_out;
+			stream->avail_out = MAX_LEN;
+
+			ret = nx_deflate(stream, Z_FINISH);
+			write(state->fd, next_out, MAX_LEN - stream->avail_out);
+		} while (ret != Z_STREAM_END);
+
+		ret = nx_deflateEnd(stream);
+	} else
+		ret = nx_inflateEnd(stream);
+
+	if(state->fp == NULL)
+		close(state->fd);
+	else
+		fclose(state->fp);
+
+	free(next_out);
+	free(state);
+
+	return ret;
+}
+
+gzFile nx_gzdopen(int fd, const char *mode)
+{
+	return nx_gzopen_(NULL, fd, mode);
+}
+
+gzFile nx_gzopen(const char* path, const char *mode)
+{
+	return nx_gzopen_(path, 0, mode);
+}
+
+gzFile nx_gzopen_(const char* path, int fd, const char *mode)
+{
+	gz_statep state;
+	gzFile file;
+	int err, strategy = Z_DEFAULT_STRATEGY, level = Z_DEFAULT_COMPRESSION;
+	char* digit;
+	void* stream;
+
+	state = malloc(sizeof(struct gz_state));
+	if (state == NULL)
+		return NULL;
+	memset(state, 0, sizeof(struct gz_state));
+
+	if (path == NULL){
+		state->fp = NULL;
+		if(fdopen(fd, mode) != NULL)
+			state->fd = fd;
+		else
+			state->fd = -1;
+	} else {
+		state->fp = fopen(path, mode);
+		state->fd = fileno(state->fp);
+	}
+
+	if (state->fd == -1){
+		free(state);
+		return NULL;
+	}
+
+	stream = &(state->strm);
+	memset(stream, 0, sizeof(z_stream));
+	if (strchr(mode, 'w')){
+		if (strchr(mode, 'h'))
+			strategy = Z_HUFFMAN_ONLY;
+		else if (strchr(mode, 'f'))
+			strategy = Z_FILTERED;
+		else if (strchr(mode, 'R'))
+			strategy = Z_RLE;
+
+		digit = strpbrk(mode, "0123456789");
+		if (digit != NULL)
+			level = atoi(digit);
+
+		err = nx_deflateInit2(stream, level, Z_DEFLATED, 31,
+					DEF_MEM_LEVEL, strategy);
+		state->deflate = true;
+	} else {
+		err = nx_inflateInit(stream);
+		state->deflate = false;
+	}
+	if (err != Z_OK){
+		free(state);
+		if (err == Z_STREAM_ERROR)
+			errno = EINVAL;
+		return NULL;
+	}
+
+	file = (gzFile) state;
+	return file;
+}

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -1819,13 +1819,18 @@ int nx_inflateSetDictionary(z_streamp strm, const Bytef *dictionary, uInt dictLe
 	if (NULL == (s = (nx_streamp) strm->state))
 		return Z_STREAM_ERROR;
 
+	if (s->wrap == (HEADER_ZLIB | HEADER_GZIP)) {
+		prt_err("inflateSetDictionary error: inflate did not detect the header yet.\n");
+		return Z_STREAM_ERROR;
+	}
+
 	if (s->wrap == HEADER_GZIP) {
 		/* gzip doesn't allow dictionaries; */
 		prt_err("inflateSetDictionary error: gzip format does not permit dictionary\n");
 		return Z_STREAM_ERROR;
 	}
 
-	if (s->inf_state != inf_state_zlib_dict && s->wrap == HEADER_ZLIB ) {
+	if (s->inf_state != inf_state_zlib_dict && s->wrap == HEADER_ZLIB) {
 		prt_err("inflateSetDictionary error: inflate did not ask for a dictionary\n");
 		return Z_STREAM_ERROR;
 	}

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -639,6 +639,10 @@ extern int sw_uncompress(Bytef *dest, uLongf *destLen, const Bytef *source, uLon
 #if ZLIB_VERNUM >= 0x1290
 extern int sw_uncompress2(Bytef *dest, uLongf *destLen, const Bytef *source, uLong *sourceLen);
 #endif
+extern int sw_gzclose(gzFile file);
+extern gzFile sw_gzopen(const char* path, const char *mode);
+extern gzFile sw_gzdopen(int fd, const char *mode);
+extern int sw_gzwrite(gzFile file, const void *buf, unsigned len);
 
 extern int sw_inflateInit_(z_streamp strm, const char *version, int stream_size);
 extern int sw_inflateInit2_(z_streamp strm, int  windowBits, const char *version, int stream_size);

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -618,6 +618,7 @@ extern void *dht_copy(void *handle);
 extern int nx_gzclose(gzFile file);
 extern gzFile nx_gzopen(const char* path, const char *mode);
 extern gzFile nx_gzdopen(int fd, const char *mode);
+extern int nx_gzwrite(gzFile file, const void *buf, unsigned len);
 
 /* sw_zlib.c */
 extern int sw_zlib_init(void);

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -2,7 +2,7 @@
  * NX-GZIP compression accelerator user library
  * implementing zlib library interfaces
  *
- * Copyright (C) IBM Corporation, 2011-2017
+ * Copyright (C) IBM Corporation, 2011-2022
  *
  * Licenses for GPLv2 and Apache v2.0:
  *
@@ -113,11 +113,12 @@ struct selector {
 #define HEADER_ZLIB  1
 #define HEADER_GZIP  2
 
+/* 47 is the max windowBits for auto detect header */
 #ifndef MAX_WBITS
-#  define MAX_WBITS 15
+#  define MAX_WBITS 47
 #endif
 #ifndef DEF_WBITS
-#  define DEF_WBITS MAX_WBITS
+#  define DEF_WBITS 47
 #endif
 
 #define NXQWSZ  (sizeof(nx_qw_t))
@@ -612,6 +613,11 @@ extern void *dht_begin(char *ifile, char *ofile);
 extern void dht_end(void *handle);
 extern int dht_lookup(nx_gzip_crb_cpb_t *cmdp, int request, void *handle);
 extern void *dht_copy(void *handle);
+
+/* nx_gzip.c */
+extern int nx_gzclose(gzFile file);
+extern gzFile nx_gzopen(const char* path, const char *mode);
+extern gzFile nx_gzdopen(int fd, const char *mode);
 
 /* sw_zlib.c */
 extern int sw_zlib_init(void);

--- a/lib/sw_zlib.c
+++ b/lib/sw_zlib.c
@@ -197,6 +197,13 @@ gzFile sw_gzdopen(int fd, const char *mode)
 	return (* p_gzdopen)(fd, mode);
 }
 
+static int (* p_gzread)(gzFile file, void *buf, unsigned len);
+int sw_gzread(gzFile file, void *buf, unsigned len)
+{
+	check_sym(p_gzread, Z_STREAM_ERROR);
+	return (* p_gzread)(file, buf, len);
+}
+
 static int (*p_gzwrite)(gzFile file, const void *buf, unsigned len);
 int sw_gzwrite (gzFile file, const void *buf, unsigned len)
 {
@@ -339,6 +346,7 @@ int sw_zlib_init(void)
 	register_sym(gzclose);
 	register_sym(gzopen);
 	register_sym(gzdopen);
+	register_sym(gzread);
 	register_sym(gzwrite);
 	register_sym(inflateInit_);
 	register_sym(inflateInit2_);

--- a/lib/sw_zlib.c
+++ b/lib/sw_zlib.c
@@ -2,7 +2,7 @@
  * NX-GZIP compression accelerator user library
  * implementing zlib compression library interfaces
  *
- * Copyright (C) IBM Corporation, 2011-2021
+ * Copyright (C) IBM Corporation, 2011-2022
  *
  * Licenses for GPLv2 and Apache v2.0:
  *
@@ -176,6 +176,34 @@ int sw_uncompress2(Bytef *dest, uLongf *destLen, const Bytef *source, uLong *sou
 	return (* p_uncompress2)(dest, destLen, source, sourceLen);
 }
 
+static int (* p_gzclose)(gzFile file);
+int sw_gzclose(gzFile file)
+{
+	check_sym(p_gzclose, Z_STREAM_ERROR);
+	return (* p_gzclose)(file);
+}
+
+static gzFile (* p_gzopen)(const char * path, const char *mode);
+gzFile sw_gzopen(const char * path, const char *mode)
+{
+	check_sym(p_gzopen, NULL);
+	return (* p_gzopen)(path, mode);
+}
+
+static gzFile (* p_gzdopen)(int fd, const char *mode);
+gzFile sw_gzdopen(int fd, const char *mode)
+{
+	check_sym(p_gzdopen, NULL);
+	return (* p_gzdopen)(fd, mode);
+}
+
+static int (*p_gzwrite)(gzFile file, const void *buf, unsigned len);
+int sw_gzwrite (gzFile file, const void *buf, unsigned len)
+{
+	check_sym(p_gzwrite, Z_STREAM_ERROR);
+	return (* p_gzwrite)(file, buf, len);
+}
+
 static int (* p_inflateInit_)(z_streamp strm, const char *version, int stream_size);
 int sw_inflateInit_(z_streamp strm, const char *version, int stream_size)
 {
@@ -308,7 +336,10 @@ int sw_zlib_init(void)
 #if ZLIB_VERNUM >= 0x1290
 	register_sym(uncompress2);
 #endif
-
+	register_sym(gzclose);
+	register_sym(gzopen);
+	register_sym(gzdopen);
+	register_sym(gzwrite);
 	register_sym(inflateInit_);
 	register_sym(inflateInit2_);
 	register_sym(inflateReset);

--- a/libnxz.h
+++ b/libnxz.h
@@ -2,7 +2,7 @@
  * NX-GZIP compression accelerator user library
  * implementing zlib library interfaces
  *
- * Copyright (C) IBM Corporation, 2020
+ * Copyright (C) IBM Corporation, 2020-2022
  *
  * Licenses for GPLv2 and Apache v2.0:
  *
@@ -109,6 +109,11 @@ extern int nx_uncompress2(unsigned char *dest, ulong *destLen,
 extern int nx_uncompress(unsigned char *dest, ulong *destLen,
 			 const unsigned char *source, ulong sourceLen);
 
+/* nx_gzip.c */
+extern int nx_gzclose(gzFile file);
+extern gzFile nx_gzopen(const char* path, const char *mode);
+extern gzFile nx_gzdopen(int fd, const char *mode);
+extern int nx_gzwrite(gzFile file, const void *buf, unsigned len);
 
 extern int deflateInit_(void *strm, int level, const char* version,
 			int stream_size);
@@ -178,5 +183,9 @@ extern int uncompress(unsigned char *dest, ulong *destLen,
 		      const unsigned char *source, ulong sourceLen);
 extern int uncompress2(unsigned char *dest, ulong *destLen,
 		       const unsigned char *source, ulong *sourceLen);
+extern int gzclose(gzFile file);
+extern gzFile gzopen(const char* path, const char *mode);
+extern gzFile gzdopen(int fd, const char *mode);
+extern int gzwrite(gzFile file, void *buf, unsigned len);
 
 #endif /* _LIBNXZ_H */

--- a/libnxz.h
+++ b/libnxz.h
@@ -113,6 +113,7 @@ extern int nx_uncompress(unsigned char *dest, ulong *destLen,
 extern int nx_gzclose(gzFile file);
 extern gzFile nx_gzopen(const char* path, const char *mode);
 extern gzFile nx_gzdopen(int fd, const char *mode);
+extern int nx_gzread(FILE file, void *buf, unsigned len);
 extern int nx_gzwrite(gzFile file, const void *buf, unsigned len);
 
 extern int deflateInit_(void *strm, int level, const char* version,
@@ -186,6 +187,7 @@ extern int uncompress2(unsigned char *dest, ulong *destLen,
 extern int gzclose(gzFile file);
 extern gzFile gzopen(const char* path, const char *mode);
 extern gzFile gzdopen(int fd, const char *mode);
+extern int gzread(FILE file, void *buf, unsigned len);
 extern int gzwrite(gzFile file, void *buf, unsigned len);
 
 #endif /* _LIBNXZ_H */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -11,7 +11,7 @@ test_exe = test_adler32 \
 	   test_multithread_stress \
 	   test_pid_reuse
 
-selector_tests = test_stress test_deflate test_inflate test_dict
+selector_tests = test_stress test_deflate test_inflate test_dict test_gz
 other_tests = test_zeroinput
 
 TESTS = $(test_exe) $(test_scripts) \
@@ -56,6 +56,8 @@ test_zeroinput_SOURCES = test_zeroinput.c test_utils.c
 
 test_dict_SOURCES = test_dict.c test_utils.c
 
+test_gz_SOURCES = test_gz.c test_utils.c
+
 ABIDW_FLAGS = --no-corpus-path --drop-undefined-syms --drop-private-types \
 	      --no-comp-dir-path --no-show-locs --type-id-style hash
 
@@ -86,3 +88,6 @@ regen-abi:
 	@echo "    abidw $(ABIDW_FLAGS) /path/to/libz.so > libz.abi"
 
 build-TESTS: $(check_PROGRAMS) $(check_SCRIPTS)
+
+clean-local:
+	-rm -f test_gzfile*.gz

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -111,7 +111,7 @@ am__EXEEXT_1 = test_adler32$(EXEEXT) test_buf_error$(EXEEXT) \
 	test_crc32$(EXEEXT) test_inflatesyncpoint$(EXEEXT) \
 	test_multithread_stress$(EXEEXT) test_pid_reuse$(EXEEXT)
 am__EXEEXT_2 = test_stress$(EXEEXT) test_deflate$(EXEEXT) \
-	test_inflate$(EXEEXT) test_dict$(EXEEXT)
+	test_inflate$(EXEEXT) test_dict$(EXEEXT) test_gz$(EXEEXT)
 am__EXEEXT_3 = test_zeroinput$(EXEEXT)
 am_test_adler32_OBJECTS = test_adler32.$(OBJEXT)
 test_adler32_OBJECTS = $(am_test_adler32_OBJECTS)
@@ -143,6 +143,10 @@ am_test_dict_OBJECTS = test_dict.$(OBJEXT) test_utils.$(OBJEXT)
 test_dict_OBJECTS = $(am_test_dict_OBJECTS)
 test_dict_LDADD = $(LDADD)
 test_dict_DEPENDENCIES = ../lib/libnxz.la $(am__DEPENDENCIES_1)
+am_test_gz_OBJECTS = test_gz.$(OBJEXT) test_utils.$(OBJEXT)
+test_gz_OBJECTS = $(am_test_gz_OBJECTS)
+test_gz_LDADD = $(LDADD)
+test_gz_DEPENDENCIES = ../lib/libnxz.la $(am__DEPENDENCIES_1)
 am_test_inflate_OBJECTS = test_inflate.$(OBJEXT) test_utils.$(OBJEXT) \
 	inflate/random_buffer.$(OBJEXT)
 test_inflate_OBJECTS = $(am_test_inflate_OBJECTS)
@@ -192,7 +196,7 @@ am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = ./$(DEPDIR)/test_adler32.Po \
 	./$(DEPDIR)/test_buf_error.Po ./$(DEPDIR)/test_crc32.Po \
 	./$(DEPDIR)/test_deflate.Po ./$(DEPDIR)/test_dict.Po \
-	./$(DEPDIR)/test_inflate.Po \
+	./$(DEPDIR)/test_gz.Po ./$(DEPDIR)/test_inflate.Po \
 	./$(DEPDIR)/test_inflatesyncpoint.Po \
 	./$(DEPDIR)/test_multithread_stress.Po \
 	./$(DEPDIR)/test_pid_reuse.Po ./$(DEPDIR)/test_stress.Po \
@@ -223,14 +227,14 @@ am__v_CCLD_0 = @echo "  CCLD    " $@;
 am__v_CCLD_1 = 
 SOURCES = $(test_adler32_SOURCES) $(test_buf_error_SOURCES) \
 	$(test_crc32_SOURCES) $(test_deflate_SOURCES) \
-	$(test_dict_SOURCES) $(test_inflate_SOURCES) \
-	$(test_inflatesyncpoint_SOURCES) \
+	$(test_dict_SOURCES) $(test_gz_SOURCES) \
+	$(test_inflate_SOURCES) $(test_inflatesyncpoint_SOURCES) \
 	$(test_multithread_stress_SOURCES) $(test_pid_reuse_SOURCES) \
 	$(test_stress_SOURCES) $(test_zeroinput_SOURCES)
 DIST_SOURCES = $(test_adler32_SOURCES) $(test_buf_error_SOURCES) \
 	$(test_crc32_SOURCES) $(test_deflate_SOURCES) \
-	$(test_dict_SOURCES) $(test_inflate_SOURCES) \
-	$(test_inflatesyncpoint_SOURCES) \
+	$(test_dict_SOURCES) $(test_gz_SOURCES) \
+	$(test_inflate_SOURCES) $(test_inflatesyncpoint_SOURCES) \
 	$(test_multithread_stress_SOURCES) $(test_pid_reuse_SOURCES) \
 	$(test_stress_SOURCES) $(test_zeroinput_SOURCES)
 am__can_run_installinfo = \
@@ -442,15 +446,15 @@ am__set_TESTS_bases = \
 RECHECK_LOGS = $(TEST_LOGS)
 AM_RECURSIVE_TARGETS = check recheck
 am__EXEEXT_4 = test_stress.auto test_deflate.auto test_inflate.auto \
-	test_dict.auto
+	test_dict.auto test_gz.auto
 am__EXEEXT_5 = test_stress.sw test_deflate.sw test_inflate.sw \
-	test_dict.sw
+	test_dict.sw test_gz.sw
 am__EXEEXT_6 = test_stress.nx test_deflate.nx test_inflate.nx \
-	test_dict.nx
+	test_dict.nx test_gz.nx
 am__EXEEXT_7 = test_stress.mix test_deflate.mix test_inflate.mix \
-	test_dict.mix
+	test_dict.mix test_gz.mix
 am__EXEEXT_8 = test_stress.mix2 test_deflate.mix2 test_inflate.mix2 \
-	test_dict.mix2
+	test_dict.mix2 test_gz.mix2
 TEST_SUITE_LOG = test-suite.log
 TEST_EXTENSIONS = @EXEEXT@ .test
 LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver
@@ -634,7 +638,7 @@ test_exe = test_adler32 \
 	   test_multithread_stress \
 	   test_pid_reuse
 
-selector_tests = test_stress test_deflate test_inflate test_dict
+selector_tests = test_stress test_deflate test_inflate test_dict test_gz
 other_tests = test_zeroinput
 check_SCRIPTS = $(test_scripts)
 test_adler32_SOURCES = test_adler32.c
@@ -659,6 +663,7 @@ test_pid_reuse_SOURCES = test_pid_reuse.c
 test_stress_SOURCES = test_stress.c test_utils.c
 test_zeroinput_SOURCES = test_zeroinput.c test_utils.c
 test_dict_SOURCES = test_dict.c test_utils.c
+test_gz_SOURCES = test_gz.c test_utils.c
 ABIDW_FLAGS = --no-corpus-path --drop-undefined-syms --drop-private-types \
 	      --no-comp-dir-path --no-show-locs --type-id-style hash
 
@@ -742,6 +747,10 @@ test_deflate$(EXEEXT): $(test_deflate_OBJECTS) $(test_deflate_DEPENDENCIES) $(EX
 test_dict$(EXEEXT): $(test_dict_OBJECTS) $(test_dict_DEPENDENCIES) $(EXTRA_test_dict_DEPENDENCIES) 
 	@rm -f test_dict$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_dict_OBJECTS) $(test_dict_LDADD) $(LIBS)
+
+test_gz$(EXEEXT): $(test_gz_OBJECTS) $(test_gz_DEPENDENCIES) $(EXTRA_test_gz_DEPENDENCIES)
+	@rm -f test_gz$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(test_gz_OBJECTS) $(test_gz_LDADD) $(LIBS)
 inflate/$(am__dirstamp):
 	@$(MKDIR_P) inflate
 	@: > inflate/$(am__dirstamp)
@@ -788,6 +797,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_crc32.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_deflate.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_dict.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_gz.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_inflate.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_inflatesyncpoint.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_multithread_stress.Po@am__quote@ # am--include-marker
@@ -1109,6 +1119,13 @@ test_dict.auto.log: test_dict.auto
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test_gz.auto.log: test_gz.auto
+	@p='test_gz.auto'; \
+	b='test_gz.auto'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 test_stress.sw.log: test_stress.sw
 	@p='test_stress.sw'; \
 	b='test_stress.sw'; \
@@ -1133,6 +1150,13 @@ test_inflate.sw.log: test_inflate.sw
 test_dict.sw.log: test_dict.sw
 	@p='test_dict.sw'; \
 	b='test_dict.sw'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test_gz.sw.log: test_gz.sw
+	@p='test_gz.sw'; \
+	b='test_gz.sw'; \
 	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
@@ -1165,6 +1189,13 @@ test_dict.nx.log: test_dict.nx
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test_gz.nx.log: test_gz.nx
+	@p='test_gz.nx'; \
+	b='test_gz.nx'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 test_stress.mix.log: test_stress.mix
 	@p='test_stress.mix'; \
 	b='test_stress.mix'; \
@@ -1193,6 +1224,13 @@ test_dict.mix.log: test_dict.mix
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test_gz.mix.log: test_gz.mix
+	@p='test_gz.mix'; \
+	b='test_gz.mix'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 test_stress.mix2.log: test_stress.mix2
 	@p='test_stress.mix2'; \
 	b='test_stress.mix2'; \
@@ -1217,6 +1255,13 @@ test_inflate.mix2.log: test_inflate.mix2
 test_dict.mix2.log: test_dict.mix2
 	@p='test_dict.mix2'; \
 	b='test_dict.mix2'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test_gz.mix2.log: test_gz.mix2
+	@p='test_gz.mix2'; \
+	b='test_gz.mix2'; \
 	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
@@ -1321,7 +1366,7 @@ maintainer-clean-generic:
 	@echo "it deletes files that may require special tools to rebuild."
 clean: clean-am
 
-clean-am: clean-checkPROGRAMS clean-generic clean-libtool \
+clean-am: clean-checkPROGRAMS clean-generic clean-libtool clean-local \
 	mostlyclean-am
 
 distclean: distclean-am
@@ -1330,6 +1375,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/test_crc32.Po
 	-rm -f ./$(DEPDIR)/test_deflate.Po
 	-rm -f ./$(DEPDIR)/test_dict.Po
+	-rm -f ./$(DEPDIR)/test_gz.Po
 	-rm -f ./$(DEPDIR)/test_inflate.Po
 	-rm -f ./$(DEPDIR)/test_inflatesyncpoint.Po
 	-rm -f ./$(DEPDIR)/test_multithread_stress.Po
@@ -1394,6 +1440,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/test_crc32.Po
 	-rm -f ./$(DEPDIR)/test_deflate.Po
 	-rm -f ./$(DEPDIR)/test_dict.Po
+	-rm -f ./$(DEPDIR)/test_gz.Po
 	-rm -f ./$(DEPDIR)/test_inflate.Po
 	-rm -f ./$(DEPDIR)/test_inflatesyncpoint.Po
 	-rm -f ./$(DEPDIR)/test_multithread_stress.Po
@@ -1430,17 +1477,18 @@ uninstall-am:
 
 .PHONY: CTAGS GTAGS TAGS all all-am am--depfiles check check-TESTS \
 	check-am clean clean-checkPROGRAMS clean-generic clean-libtool \
-	cscopelist-am ctags ctags-am distclean distclean-compile \
-	distclean-generic distclean-libtool distclean-tags distdir dvi \
-	dvi-am html html-am info info-am install install-am \
-	install-data install-data-am install-dvi install-dvi-am \
-	install-exec install-exec-am install-html install-html-am \
-	install-info install-info-am install-man install-pdf \
-	install-pdf-am install-ps install-ps-am install-strip \
-	installcheck installcheck-am installdirs maintainer-clean \
-	maintainer-clean-generic mostlyclean mostlyclean-compile \
-	mostlyclean-generic mostlyclean-libtool pdf pdf-am ps ps-am \
-	recheck tags tags-am uninstall uninstall-am
+	clean-local cscopelist-am ctags ctags-am distclean \
+	distclean-compile distclean-generic distclean-libtool \
+	distclean-tags distdir dvi dvi-am html html-am info info-am \
+	install install-am install-data install-data-am install-dvi \
+	install-dvi-am install-exec install-exec-am install-html \
+	install-html-am install-info install-info-am install-man \
+	install-pdf install-pdf-am install-ps install-ps-am \
+	install-strip installcheck installcheck-am installdirs \
+	maintainer-clean maintainer-clean-generic mostlyclean \
+	mostlyclean-compile mostlyclean-generic mostlyclean-libtool \
+	pdf pdf-am ps ps-am recheck tags tags-am uninstall \
+	uninstall-am
 
 .PRECIOUS: Makefile
 
@@ -1472,6 +1520,9 @@ regen-abi:
 	@echo "    abidw $(ABIDW_FLAGS) /path/to/libz.so > libz.abi"
 
 build-TESTS: $(check_PROGRAMS) $(check_SCRIPTS)
+
+clean-local:
+	-rm -f test_gzfile*.gz
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/test/libnxz.abi
+++ b/test/libnxz.abi
@@ -27,6 +27,7 @@
     <elf-symbol name='gzclose' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='gzdopen' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='gzopen' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzread' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='gzwrite' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='inflate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='inflateCopy' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -60,6 +61,7 @@
     <elf-symbol name='nx_gzclose' version='LIBNXZ_0.64.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_gzdopen' version='LIBNXZ_0.64.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_gzopen' version='LIBNXZ_0.64.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nx_gzread' version='LIBNXZ_0.64.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_gzwrite' version='LIBNXZ_0.64.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_inflate' version='LIBNXZ_0.61.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_inflateCopy' version='LIBNXZ_0.61.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -439,6 +441,12 @@
       <parameter type-id='f0981eeb' name='len'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='gzread' mangled-name='gzread' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzread'>
+      <parameter type-id='45259bf7' name='file'/>
+      <parameter type-id='eaa32e2f' name='buf'/>
+      <parameter type-id='f0981eeb' name='len'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='gzdopen' mangled-name='gzdopen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdopen'>
       <parameter type-id='95e97e5e' name='fd'/>
       <parameter type-id='80f4b756' name='mode'/>
@@ -454,6 +462,12 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nx_gzwrite' mangled-name='nx_gzwrite' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nx_gzwrite@@LIBNXZ_0.64.0'>
+      <parameter type-id='45259bf7' name='file'/>
+      <parameter type-id='eaa32e2f' name='buf'/>
+      <parameter type-id='f0981eeb' name='len'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nx_gzread' mangled-name='nx_gzread' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nx_gzread@@LIBNXZ_0.64.0'>
       <parameter type-id='45259bf7' name='file'/>
       <parameter type-id='eaa32e2f' name='buf'/>
       <parameter type-id='f0981eeb' name='len'/>

--- a/test/libnxz.abi
+++ b/test/libnxz.abi
@@ -56,6 +56,7 @@
     <elf-symbol name='nx_gzclose' version='LIBNXZ_0.64.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_gzdopen' version='LIBNXZ_0.64.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_gzopen' version='LIBNXZ_0.64.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nx_gzwrite' version='LIBNXZ_0.64.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_inflate' version='LIBNXZ_0.61.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_inflateCopy' version='LIBNXZ_0.61.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_inflateEnd' version='LIBNXZ_0.61.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -423,6 +424,12 @@
     </class-decl>
     <pointer-type-def type-id='fbc67d64' size-in-bits='64' id='9149c942'/>
     <pointer-type-def type-id='002ac4a6' size-in-bits='64' id='cf536864'/>
+    <function-decl name='nx_gzwrite' mangled-name='nx_gzwrite' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nx_gzwrite@@LIBNXZ_0.64.0'>
+      <parameter type-id='45259bf7' name='file'/>
+      <parameter type-id='eaa32e2f' name='buf'/>
+      <parameter type-id='f0981eeb' name='len'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='nx_gzopen' mangled-name='nx_gzopen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nx_gzopen@@LIBNXZ_0.64.0'>
       <parameter type-id='80f4b756' name='path'/>
       <parameter type-id='80f4b756' name='mode'/>

--- a/test/libnxz.abi
+++ b/test/libnxz.abi
@@ -24,6 +24,10 @@
     <elf-symbol name='deflateResetKeep' version='ZLIB_1.2.5.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='deflateSetDictionary' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='deflateSetHeader' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclose' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzdopen' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzopen' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzwrite' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='inflate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='inflateCopy' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='inflateEnd' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -73,6 +77,9 @@
     <elf-symbol name='uncompress2' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zlibVersion' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='is_deflate' size='1' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
   <abi-instr version='1.0' address-size='64' path='gzip_vas.c' language='LANG_C11'>
     <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
     <type-decl name='void' id='48b5725f'/>
@@ -410,6 +417,7 @@
     </function-type>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='nx_gzlib.c' language='LANG_C11'>
+    <type-decl name='bool' size-in-bits='8' id='c894953d'/>
     <typedef-decl name='gzFile' type-id='9149c942' id='45259bf7'/>
     <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' id='fbc67d64'>
       <data-member access='public' layout-offset-in-bits='0'>
@@ -424,6 +432,27 @@
     </class-decl>
     <pointer-type-def type-id='fbc67d64' size-in-bits='64' id='9149c942'/>
     <pointer-type-def type-id='002ac4a6' size-in-bits='64' id='cf536864'/>
+    <var-decl name='is_deflate' type-id='c894953d' mangled-name='is_deflate' visibility='default' elf-symbol-id='is_deflate'/>
+    <function-decl name='gzwrite' mangled-name='gzwrite' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzwrite'>
+      <parameter type-id='45259bf7' name='file'/>
+      <parameter type-id='eaa32e2f' name='buf'/>
+      <parameter type-id='f0981eeb' name='len'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='gzdopen' mangled-name='gzdopen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdopen'>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='80f4b756' name='mode'/>
+      <return type-id='45259bf7'/>
+    </function-decl>
+    <function-decl name='gzopen' mangled-name='gzopen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen'>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='80f4b756' name='mode'/>
+      <return type-id='45259bf7'/>
+    </function-decl>
+    <function-decl name='gzclose' mangled-name='gzclose' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose'>
+      <parameter type-id='45259bf7' name='file'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='nx_gzwrite' mangled-name='nx_gzwrite' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nx_gzwrite@@LIBNXZ_0.64.0'>
       <parameter type-id='45259bf7' name='file'/>
       <parameter type-id='eaa32e2f' name='buf'/>

--- a/test/libnxz.abi
+++ b/test/libnxz.abi
@@ -53,6 +53,9 @@
     <elf-symbol name='nx_deflateReset' version='LIBNXZ_0.61.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_deflateSetDictionary' version='LIBNXZ_0.61.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_deflateSetHeader' version='LIBNXZ_0.61.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nx_gzclose' version='LIBNXZ_0.64.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nx_gzdopen' version='LIBNXZ_0.64.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nx_gzopen' version='LIBNXZ_0.64.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_inflate' version='LIBNXZ_0.61.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_inflateCopy' version='LIBNXZ_0.61.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nx_inflateEnd' version='LIBNXZ_0.61.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -405,6 +408,36 @@
       <return type-id='48b5725f'/>
     </function-type>
   </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='nx_gzlib.c' language='LANG_C11'>
+    <typedef-decl name='gzFile' type-id='9149c942' id='45259bf7'/>
+    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' id='fbc67d64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='have' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='next' type-id='cf536864' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pos' type-id='ad707ada' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='fbc67d64' size-in-bits='64' id='9149c942'/>
+    <pointer-type-def type-id='002ac4a6' size-in-bits='64' id='cf536864'/>
+    <function-decl name='nx_gzopen' mangled-name='nx_gzopen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nx_gzopen@@LIBNXZ_0.64.0'>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='80f4b756' name='mode'/>
+      <return type-id='45259bf7'/>
+    </function-decl>
+    <function-decl name='nx_gzdopen' mangled-name='nx_gzdopen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nx_gzdopen@@LIBNXZ_0.64.0'>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='80f4b756' name='mode'/>
+      <return type-id='45259bf7'/>
+    </function-decl>
+    <function-decl name='nx_gzclose' mangled-name='nx_gzclose' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nx_gzclose@@LIBNXZ_0.64.0'>
+      <parameter type-id='45259bf7' name='file'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+  </abi-instr>
   <abi-instr version='1.0' address-size='64' path='nx_inflate.c' language='LANG_C11'>
     <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSyncPoint'>
       <parameter type-id='fb4f8c25' name='strm'/>
@@ -446,6 +479,13 @@
     </function-decl>
     <function-decl name='inflateReset' mangled-name='inflateReset' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset'>
       <parameter type-id='fb4f8c25' name='strm'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit2_'>
+      <parameter type-id='fb4f8c25' name='strm'/>
+      <parameter type-id='95e97e5e' name='windowBits'/>
+      <parameter type-id='80f4b756' name='version'/>
+      <parameter type-id='95e97e5e' name='stream_size'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='inflateInit_' mangled-name='inflateInit_' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit_'>
@@ -502,13 +542,6 @@
     </function-decl>
     <function-decl name='nx_inflateResetKeep' mangled-name='nx_inflateResetKeep' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nx_inflateResetKeep@@LIBNXZ_0.61.0'>
       <parameter type-id='fb4f8c25' name='strm'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit2_'>
-      <parameter type-id='fb4f8c25' name='strm'/>
-      <parameter type-id='95e97e5e' name='windowBits'/>
-      <parameter type-id='80f4b756' name='version'/>
-      <parameter type-id='95e97e5e' name='stream_size'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
@@ -630,13 +663,21 @@
         <var-decl name='strategy_override' type-id='95e97e5e' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='736'>
-        <var-decl name='gzip_selector' type-id='b96825af' visibility='default'/>
+        <var-decl name='mode' type-id='8971ed04' visibility='default'/>
       </data-member>
     </class-decl>
     <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
     <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
     <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
     <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
+    <class-decl name='selector' size-in-bits='16' is-struct='yes' visibility='default' id='8971ed04'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='inflate' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='deflate' type-id='b96825af' visibility='default'/>
+      </data-member>
+    </class-decl>
     <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
     <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='ec1ed955'>
       <data-member access='public' layout-offset-in-bits='0'>

--- a/test/test_gz.c
+++ b/test/test_gz.c
@@ -1,0 +1,180 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "test.h"
+#include "test_utils.h"
+
+#define DATALEN 1024*1024 // 1MB
+#define CHUNK	8192
+
+int test_nx_gzwrite(Byte *src, int size, char *filename)
+{
+	gzFile file;
+	int rc;
+
+	file = nx_gzopen(filename,"wb");
+	if (file == NULL) {
+		printf("*** failed gzopen!\n");
+		return TEST_ERROR;
+	}
+
+	rc = nx_gzwrite(file, src, size);
+
+	if (rc != size) {
+		printf("*** failed: gzwrite returned %d, size is %d\n", rc,
+			size);
+		return TEST_ERROR;
+	}
+
+	if (nx_gzclose(file) != Z_OK) {
+		printf("*** failed gzclose!\n");
+		return TEST_ERROR;
+	}
+
+	return TEST_OK;
+}
+
+int test_nx_gzread(Byte *src, Byte *dest, int src_size, char *filename)
+{
+	gzFile file;
+	int rc;
+
+	file = nx_gzopen(filename,"rb");
+	if (file == NULL) {
+		printf("*** failed gzopen!\n");
+		return TEST_ERROR;
+	}
+
+	rc = nx_gzread(file, dest, src_size);
+
+	if (rc <= 0) {
+		printf("*** failed: gzread returned %d\n", rc);
+		return TEST_ERROR;
+	}
+
+	if (nx_gzclose(file) != Z_OK) {
+		printf("*** failed gzclose!\n");
+		return TEST_ERROR;
+	}
+
+	if (compare_data(src, dest, src_size))
+		return TEST_ERROR;
+
+	return TEST_OK;
+}
+
+int test_gzwrite(Byte *src, int size, char *filename)
+{
+	gzFile file;
+	Byte *cur = src;
+	int rc;
+
+	file = gzopen(filename,"wb");
+	if (file == NULL) {
+		printf("*** failed gzopen!\n");
+		return TEST_ERROR;
+	}
+
+	for(int i = 0; i < size; i += CHUNK) {
+		rc = gzwrite(file, cur, CHUNK);
+		cur += CHUNK;
+		if (rc <= 0) {
+			printf("*** failed: gzread returned %d\n", rc);
+			return TEST_ERROR;
+		}
+	}
+
+	if (gzclose(file) != Z_OK) {
+		printf("*** failed gzclose!\n");
+		return TEST_ERROR;
+	}
+
+	return TEST_OK;
+}
+
+int test_gzread(Byte *src, Byte *dest, int src_size, char *filename)
+{
+	gzFile file;
+	Byte *cur = dest;
+	int rc;
+
+	file = gzopen(filename,"rb");
+	if (file == NULL) {
+		printf("*** failed gzopen!\n");
+		return TEST_ERROR;
+	}
+
+	do {
+		rc = gzread(file, cur, CHUNK);
+		if (rc < 0) {
+			printf("*** failed: gzread returned %d\n", rc);
+			return TEST_ERROR;
+		}
+
+		if (rc == 0) break;
+
+		cur += rc;
+	} while(1);
+
+	if (gzclose(file) != Z_OK) {
+		printf("*** failed gzclose!\n");
+		return TEST_ERROR;
+	}
+
+	if (compare_data(src, dest, src_size))
+		return TEST_ERROR;
+
+	return TEST_OK;
+}
+
+int main()
+{
+	Byte *src, *uncompr;
+	const unsigned int src_len = DATALEN;
+	const unsigned int uncompr_len = DATALEN*2;
+	char filename[25];
+	gzFile file;
+
+	file = gzdopen(fileno(stdin), "rb");
+	if (file == NULL) {
+		printf("*** failed gzdopen stdin\n");
+		return TEST_ERROR;
+	}
+	if (gzclose(file) != Z_OK) {
+		printf("*** failed gzclose stdin\n");
+		return TEST_ERROR;
+	}
+
+	generate_random_data(src_len);
+	src = (Byte*)&ran_data[0];
+
+	uncompr = (Byte*)calloc((uInt)uncompr_len, 1);
+	if (uncompr == NULL )
+		test_error("*** alloc buffer failed\n");
+
+	sprintf(filename, "test_gzfile_%d.gz", getpid());
+
+	printf("Testing nx_gzwrite...\n");
+	if(test_nx_gzwrite(src, src_len, filename))
+		goto err;
+	if(test_gzread(src, uncompr, src_len, filename))
+		goto err;
+
+	remove(filename);
+	memset(uncompr, 0, uncompr_len);
+
+	printf("Testing nx_gzwread...\n");
+	if(test_gzwrite(src, src_len, filename))
+		goto err;
+	if(test_nx_gzread(src, uncompr, src_len, filename))
+		goto err;
+
+	remove(filename);
+	free(uncompr);
+	printf("*** %s passed!\n", __FILE__);
+	return TEST_OK;
+err:
+	remove(filename);
+	free(uncompr);
+	return TEST_ERROR;
+}


### PR DESCRIPTION
This PR adds NX versions for gzopen, gzclose, gzwrite and gzread.
I'm hitting CC 66 with `nx_gzread` both on libnxz and zlib compressed files:
```
pid 2855471: Info: uncompress begin: len 16384
pid 2855471: nx_inflate.c:1367: Error: error: cc = 66, cc = 0x42
pid 2855471: nx_inflate.c:1370: Error: CSB: 0x 80 00 42 60
pid 2855471: nx_inflate.c:1370: Error: CSB: 0x 80 00 42 60
pid 2855471: nx_inflate.c:1370: Error: CSB: 0x 80 00 42 60
pid 2855471: nx_inflate.c:1370: Error: CSB: 0x 80 00 42 60
pid 2855471: nx_inflate.c:1690: Error: rc -3
```
I'll also add tests for these new functions.