### PR TITLE
Fix build on RHEL7

### DIFF
--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -543,7 +543,7 @@ extern uint64_t nx_wait_ticks(uint64_t ticks, uint64_t accumulated_ticks, int do
 extern unsigned long nx_crc32_combine(unsigned long crc1, unsigned long crc2, uint64_t len2);
 extern unsigned long nx_adler32_combine(unsigned long adler1, unsigned long adler2, off_t len2);
 extern unsigned long nx_crc32(unsigned long crc, const unsigned char *buf, uint64_t len);
-extern unsigned long nx_adler32(unsigned long adler, const char *buf, z_size_t len);
+extern unsigned long nx_adler32(unsigned long adler, const char *buf, unsigned int len);
 
 /* nx_zlib.c */
 extern nx_devp_t nx_open(int nx_id);

--- a/test/test_dict.c
+++ b/test/test_dict.c
@@ -12,11 +12,12 @@
 #include "test_utils.h"
 
 #define DEF_MAX_DICT_LEN   (1L<<15)
+#define DATALEN 1024*1024 // 1MB
 
 Byte *src, *compr, *uncompr;
-const unsigned int src_len = 1024*1024; // 1 MB
-const unsigned int compr_len = src_len*2;
-const unsigned int uncompr_len = src_len*2;
+const unsigned int src_len = DATALEN;
+const unsigned int compr_len = DATALEN*2;
+const unsigned int uncompr_len = DATALEN*2;
 
 /* Creates a dictionary suitable to be used with *SetDictionary family of
  * functions. It consists of the concatenation of strings of sizes between 3 and


### PR DESCRIPTION
RHEL7 ships with a very old zlib, which did not have crc32_z/adler32_z,
neither the definition of z_size_t. But nx_adler32 was being declared
with the wrong type for len in nx_zlib.h. It now matches its zlib
counterpart.

The GCC available on RHEL7 does not allow initializing a global value
from the value of another variable. So use a macro instead.