### PR TITLE
Fix spanning flush when tebc = 0 or tebc > 5

### DIFF
--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -178,7 +178,7 @@ static inline int append_btype00_header(char *buf, uint32_t tebc, int final, int
 	blen = 0xffffffffULL & (((~blen) << 16) | blen); /* NLEN,LEN */
 	flush = ((0x1ULL & final) << shift) | *buf;
 	shift = shift + 3; /* BFINAL and BTYPE written */
-	shift = (shift <= 8) ? 8 : 16;
+	shift = (shift <= 8) ? 8 : 16; /* padding bits */
 	flush |= blen << shift; /* blen length block */
 	shift = shift + 32;
 	while (shift > 0) {
@@ -399,14 +399,14 @@ static int rewrite_spanning_flush(nx_streamp s, char *buf, uint32_t avail_out, u
 	/* now copy the flush block to the stream possibly
 	   overflowing in to fifo_out */
 	k = 0;
-	while (avail_out > 0 && k < 4) {
+	while (avail_out > 0 && k < nb) {
 		*buf++ = tmp[k+1];
 		++k;
 		--avail_out;
 	}
 	/* overflowing any remainder in to fifo_out */
 	j = 0;
-	while (k < 4) {
+	while (k < nb) {
 		*(s->fifo_out + j) = tmp[k+1];
 		++k; ++j;
 	}


### PR DESCRIPTION
The size of a literal block header ranges between 35 and 42 bits,
depending on the amount of padding bits needed to align the start of the
literal data to a byte boundary. For this reason, append_btype00_header
may write 4 or 5 bytes, and this amount is returned to the caller.

However, rewrite_spanning_flush was not taking that value into
consideration, and was always copying only 4 bytes from the tmp buffer
to the output, creating invalid block headers.