### PR TITLE
Use history during compression

### DIFF
--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -248,6 +248,7 @@ typedef struct nx_stream_s {
 	int             inf_held;
 	int		resuming;
 	int		history_len;
+	int		max_history_len;
 	int		last_comp_ratio;
 	int		is_final;
 	int		invoke_cnt;  /* the times to invoke nx inflate or nx deflate */

--- a/test/test_dict.c
+++ b/test/test_dict.c
@@ -149,14 +149,15 @@ void test_setDictionary(unsigned char* dict, int dict_len,
 int main()
 {
 	unsigned long dict_adler32;
-	unsigned char dict[DEF_MAX_DICT_LEN + 1024];
+	unsigned char dict[(1<<17) + 10];
 
 	/* lengths chosen to test the following cases:
 	   1. small, medium, maximum and over-maximum lengths
 	   2. lengths multiple of 16
-	   3. lengths not multiple of 16 */
+	   3. lengths not multiple of 16
+	   4. length greater than size of fifo_in */
 	int dict_lengths[] = {100, 783, 2520, 15341, 21769, 28800,
-		DEF_MAX_DICT_LEN, DEF_MAX_DICT_LEN + 500 };
+		DEF_MAX_DICT_LEN, DEF_MAX_DICT_LEN + 500, (1<<17)+10 };
 
 	generate_random_data(src_len);
 	src = (Byte*)&ran_data[0];


### PR DESCRIPTION
This PR adds functionality to maintain and pass history data to NX, which helps achieving better compression ratios. Right now this will be used by default, but we can limit history usage to higher compression levels in the future.

To get it right I had to touch many places in `nx_deflate.c` at once, so the diff is rather large. Unfortunately I wasn't able to split it into separate commits while guaranteeing everything was functional for each commit.

Below is a comparison of compression ratio for all files used by our  `oct` tests. `libnxz` is current `develop` branch, `libnxz w/ history` is this PR and zlib is whatever zlib version available on Debian 11.

I still haven't investigated the impact on overall throughput compression, that's why this is marked as a Draft.

| filename                     | original size |             libnxz |  libnxz w/ history |               zlib |
|--|--:|--:|--:|--:|
   | at.uncompressed              |    2496942080 | 670490807 (26.85%) | 599158145 (24.00%) | 455172323 (18.23%) |
   | calgary.uncompressed         |       3265536 |   1515417 (46.41%) |   1375807 (42.13%) |   1068355 (32.72%) |
   | initrd.uncompressed          |      58841600 |  24007696 (40.80%) |  22678637 (38.54%) |  18398071 (31.27%) |
   | linux.uncompressed           |    1019310080 | 277016818 (27.18%) | 243936993 (23.93%) | 185251455 (18.17%) |
   | Packages.uncompressed        |        216674 |    152991 (70.61%) |    148005 (68.31%) |     94062 (43.41%) |
   | patch.uncompressed           |        949514 |    356942 (37.59%) |    329506 (34.70%) |    269018 (28.33%) |
   | random12k.uncompressed       |         12288 |      4465 (36.34%) |      4465 (36.34%) |      4232 (34.44%) |
   | random13M.uncompressed       |      13631488 | 13637044 (100.04%) | 13794165 (101.19%) | 13635654 (100.03%) |
   | random16k.uncompressed       |         16384 |      8564 (52.27%) |      4556 (27.81%) |      4267 (26.04%) |
   | random4k.uncompressed        |          4096 |     4107 (100.27%) |     4107 (100.27%) |     4107 (100.27%) |
   | silesia-dickens.uncompressed |      10192446 |   4920121 (48.27%) |   4565008 (44.79%) |   3871634 (37.99%) |
   | silesia-mozilla.uncompressed |      51220480 |  24919913 (48.65%) |  22681382 (44.28%) |  19089124 (37.27%) |
   | silesia-mr.uncompressed      |       9970564 |   5080216 (50.95%) |   4925439 (49.40%) |   3675941 (36.87%) |
   | silesia-nci.uncompressed     |      33553445 |   5400767 (16.10%) |   5099454 (15.20%) |    3200188 (9.54%) |
   | silesia-ooffice.uncompressed |       6152192 |   3586821 (58.30%) |   3455765 (56.17%) |   3097294 (50.34%) |
   | silesia-osdb.uncompressed    |      10085684 |   6271468 (62.18%) |   4542795 (45.04%) |   3695170 (36.64%) |
   | silesia-reymont.uncompressed |       6627202 |   2521550 (38.05%) |   2333028 (35.20%) |   1860871 (28.08%) |
   | silesia-samba.uncompressed   |      21606400 |   7554879 (34.97%) |   6871239 (31.80%) |   5451405 (25.23%) |
   | silesia-sao.uncompressed     |       7251944 |   6012875 (82.91%) |   5849831 (80.67%) |   5331799 (73.52%) |
   | silesia-webster.uncompressed |      41458703 |  15896248 (38.34%) |  14678002 (35.40%) |  12213947 (29.46%) |
   | silesia-xml.uncompressed     |       5345280 |   1302018 (24.36%) |   1143531 (21.39%) |    687997 (12.87%) |
   | silesia-x-ray.uncompressed   |       8474240 |   6489959 (76.58%) |   6483337 (76.51%) |   6045117 (71.34%) |
   | sparse1000M.uncompressed     |    1048576000 |   10838372 (1.03%) |   12714697 (1.21%) |    1019185 (0.10%) |
   | sparse10M.uncompressed       |      10485760 |     109412 (1.04%) |     127177 (1.21%) |      10209 (0.10%) |
   | vmlinux.uncompressed         |      21982000 |   9087429 (41.34%) |   8589303 (39.07%) |   7407614 (33.70%) |
   | zero13M.uncompressed         |      13631488 |     141924 (1.04%) |     165321 (1.21%) |      13269 (0.10%) |
   | zero4k.uncompressed          |          4096 |         80 (1.95%) |         80 (1.95%) |         26 (0.63%) |
