### PR TITLE
Remove `ZLIB_API`

### DIFF
--- a/configure
+++ b/configure
@@ -815,7 +815,6 @@ with_gzip
 with_sha256sum
 with_valgrind
 with_wget
-enable_zlib_api
 enable_doxygen_doc
 enable_doxygen_man
 enable_doxygen_html
@@ -1482,7 +1481,6 @@ Optional Features:
   --disable-dependency-tracking
                           speeds up one-time build
   --disable-libtool-lock  avoid locking (might break parallel builds)
-  --disable-zlib-api      Enable compatibility with the Zlib API (default enabled)
   --disable-doxygen-doc   don't generate any doxygen documentation
   --disable-doxygen-man   don't generate doxygen manual pages
   --disable-doxygen-html  don't generate doxygen plain HTML documentation
@@ -16330,15 +16328,6 @@ fi
 
 fi
 rm -f conftest.err conftest.i conftest.$ac_ext
-
-# Check whether --enable-zlib-api was given.
-if test "${enable_zlib_api+set}" = set; then :
-  enableval=$enable_zlib_api;
-fi
-
-if test "x$enableval" != xno; then :
-  CFLAGS="$CFLAGS -DZLIB_API"
-fi
 
 # Doxygen support
 

--- a/configure.ac
+++ b/configure.ac
@@ -126,11 +126,6 @@ AC_PREPROC_IFELSE(
 		       [AC_MSG_ERROR([$CC does not support -std=gnu11])])
 ])
 
-AC_ARG_ENABLE([zlib-api],
-	      [  --disable-zlib-api      Enable compatibility with the Zlib API (default enabled)])
-AS_IF([test "x$enableval" != xno],
-      [CFLAGS="$CFLAGS -DZLIB_API"])
-
 # Doxygen support
 DX_HTML_FEATURE(ON)
 DX_MAN_FEATURE(ON)

--- a/lib/nx_adler32.c
+++ b/lib/nx_adler32.c
@@ -179,8 +179,6 @@ unsigned long nx_adler32_combine(unsigned long adler1, unsigned long adler2,
 
 /* ========================================================================= */
 
-#ifdef ZLIB_API
-
 unsigned long adler32_combine(unsigned long adler1, unsigned long adler2,
 			      off_t len2)
 	      __attribute__((alias("nx_adler32_combine")));
@@ -197,6 +195,3 @@ unsigned long adler32(unsigned long adler, const unsigned char * buf,
 unsigned long adler32_z(unsigned long adler, const unsigned char * buf,
                         size_t len)
 	      __attribute__((alias("nx_adler32")));
-
-#endif
-

--- a/lib/nx_compress.c
+++ b/lib/nx_compress.c
@@ -74,8 +74,6 @@ uLong nx_compressBound(uLong sourceLen)
     return nx_deflateBound(NULL, sourceLen);
 }
 
-#ifdef ZLIB_API
-
 int compress(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen)
 {
 	return compress2(dest, destLen, source, sourceLen, Z_DEFAULT_COMPRESSION);
@@ -107,5 +105,3 @@ uLong compressBound(uLong sourceLen)
 	return	NX_MAX(nx_deflateBound(NULL, sourceLen),
                    sw_deflateBound(NULL, sourceLen));
 }
-
-#endif

--- a/lib/nx_crc.c
+++ b/lib/nx_crc.c
@@ -440,7 +440,6 @@ uLong nx_crc32_combine64(uLong crc1, uLong crc2, off_t len2)
     return crc32_combine_(crc1, crc2, len2);
 }
 
-#ifdef ZLIB_API
 unsigned long crc32(unsigned long crc, const unsigned char FAR *buf, uInt len)
 {
     return (unsigned long) crc32_ppc(crc, buf, len);
@@ -458,5 +457,3 @@ uLong crc32_combine(uLong crc1, uLong crc2, off_t len2)
 
 uLong crc32_combine64(uLong crc1, uLong crc2, off_t len2)
       __attribute__((alias("nx_crc32_combine64")));
-
-#endif

--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -2118,7 +2118,6 @@ mem_error:
 }
 
 
-#ifdef ZLIB_API
 int deflateInit_(z_streamp strm, int level, const char* version, int stream_size)
 {
 	return deflateInit2_(strm, level, Z_DEFLATED, MAX_WBITS, DEF_MEM_LEVEL,
@@ -2328,5 +2327,3 @@ int deflateCopy(z_streamp dest, z_streamp source)
 
 	return rc;
 }
-
-#endif

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -1893,7 +1893,6 @@ int nx_inflateSyncPoint(z_streamp strm)
 	return s->sync_point;
 }
 
-#ifdef ZLIB_API
 int inflateInit_(z_streamp strm, const char *version, int stream_size)
 {
 	return inflateInit2_(strm, DEF_WBITS, version, stream_size);
@@ -2098,5 +2097,3 @@ int inflateSyncPoint(z_streamp strm)
 
 	return rc;
 }
-
-#endif

--- a/lib/nx_uncompr.c
+++ b/lib/nx_uncompr.c
@@ -87,8 +87,6 @@ int nx_uncompress(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourc
     return nx_uncompress2(dest, destLen, source, &sourceLen);
 }
 
-#ifdef ZLIB_API
-
 #if ZLIB_VERNUM >= 0x1290
 int uncompress2(Bytef *dest, uLongf *destLen, const Bytef *source, uLong *sourceLen)
 {
@@ -136,5 +134,3 @@ int uncompress(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLe
 	return rc;
 #endif
 }
-
-#endif

--- a/test/test_multithread_stress.c
+++ b/test/test_multithread_stress.c
@@ -15,13 +15,8 @@
 #define DATA_NUM	10
 
 
-#ifdef ZLIB_API
 #define COMPRESS	compress
 #define UNCOMPRESS	uncompress
-#else
-#define COMPRESS	nx_compress
-#define UNCOMPRESS	nx_uncompress
-#endif
 
 static unsigned int buf_size_array[DATA_NUM] = {4096, 4096, 65536, 65536, 131072, 131072, 262144, 262144, 1048576, 1048576};
 Byte *data_buf[DATA_NUM] = {NULL};


### PR DESCRIPTION
When the zlib API is removed from the library, the generated shared
object becomes binary incompatible with zlib and with a libnxz that
supports the zlib API.  This scenario should be avoided.

The support for dynamic switching between hardware and software
implementations require the zlib API to always be present.

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>