### PR TITLE
Minor fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -202,7 +202,7 @@ ETAGS = etags
 CTAGS = ctags
 CSCOPE = cscope
 am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/aminclude.am \
-	$(srcdir)/config.h.in compile config.guess config.sub \
+	$(srcdir)/config.h.in compile config.guess config.sub depcomp \
 	install-sh ltmain.sh missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)

--- a/configure
+++ b/configure
@@ -2502,6 +2502,8 @@ LTAGE=0
 SOVERSION="$LTCURRENT:$LTREVISION:$LTAGE"
 
 
+: ${CFLAGS="-O3 -Wall -Werror -g"}
+
 # Defines host_cpu, host_vendor, and host_os variables.
 ac_aux_dir=
 for ac_dir in "$srcdir" "$srcdir/.." "$srcdir/../.."; do
@@ -12298,8 +12300,6 @@ CC=$lt_save_CC
 # Only expand once:
 
 
-
-: ${CFLAGS="-O3 -Wall -Werror -g"}
 
 # Checks for programs.
 # Extract the first word of "$target_alias-ar", so it can be a program name with args.

--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,8 @@ LTAGE=0
 SOVERSION="$LTCURRENT:$LTREVISION:$LTAGE"
 AC_SUBST(SOVERSION)
 
+: ${CFLAGS="-O3 -Wall -Werror -g"}
+
 # Defines host_cpu, host_vendor, and host_os variables.
 AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
@@ -32,8 +34,6 @@ AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([1.10 no-define foreign subdir-objects])
 AM_MAINTAINER_MODE([disable])
 LT_INIT
-
-: ${CFLAGS="-O3 -Wall -Werror -g"}
 
 # Checks for programs.
 AC_CHECK_TARGET_TOOL([AR], [ar], [:])

--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -1013,7 +1013,7 @@ void nx_hw_init(void)
 		if (!chip_num_s)
 			chip_num_s = nx_get_cfg("dev_num", &cfg_tab);
 		if (!def_bufsz)
-			def_bufsz = nx_get_cfg("dev_buf_size", &cfg_tab);
+			def_bufsz = nx_get_cfg("def_buf_size", &cfg_tab);
 		if (!logfile)
 			logfile = nx_get_cfg("logfile", &cfg_tab);
 		if (!trace_s)

--- a/samples/compdecomp_th.c
+++ b/samples/compdecomp_th.c
@@ -73,7 +73,7 @@
 #include <pthread.h>
 #include "zlib.h"
 
-/* Caller must free the allocated buffer 
+/* Caller must free the allocated buffer
    return nonzero on error */
 int read_alloc_input_file(char *fname, char **buf, size_t *bufsize)
 {
@@ -122,7 +122,7 @@ typedef struct thread_args_t {
 	int my_id;
 	char *inbuf;
 	size_t inlen;
-        long iterations;
+	long iterations;
 	double elapsed_time;
 	uint64_t checksum;
 } thread_args_t;
@@ -148,10 +148,10 @@ void *comp_file_multith(void *argsv)
 	int tid;
 
 	inbuf = argsp->inbuf;
-	inlen = argsp->inlen;	
+	inlen = argsp->inlen;
 	iterations = argsp->iterations;
 	tid = argsp->my_id;
-	
+
 	compbuf_len = 2*inlen;
 	decompbuf_len = 2*inlen;
 
@@ -166,23 +166,23 @@ void *comp_file_multith(void *argsv)
 	if (Z_OK != compress((Bytef *)compbuf, &compdata_len, (Bytef *)inbuf, (uLong)inlen) ) {
 		fprintf(stderr, "tid %d: compress error\n", tid);
 		return (void *) -1;
-	}	
+	}
 
-	/* wait all threads to finish their first runs; want this for pretty printing */	
+	/* wait all threads to finish their first runs; want this for pretty printing */
 	pthread_barrier_wait(&barr);
-	
+
 	/* uncompress */
 	decompdata_len = decompbuf_len;
 	/* decompdata_len is the buffer length before the call;
-	   returned as actual uncompressed data len on return */	
+	   returned as actual uncompressed data len on return */
 	if (Z_OK != uncompress((Bytef *)decompbuf, &decompdata_len, (Bytef *)compbuf, (uLong)compdata_len) ) {
 		fprintf(stderr, "tid %d: uncompress error\n", tid);
-		return (void *) -1;		
+		return (void *) -1;
 	}
 
-	/* wait all threads to finish their first runs; */		
+	/* wait all threads to finish their first runs; */
 	pthread_barrier_wait(&barr);
-	
+
 	/* TIMING RUNS start here; when we report bandwidth it's the
 	   larger of the input and output; for compress it is input
 	   size divided by time for decompress it is output size
@@ -194,16 +194,16 @@ void *comp_file_multith(void *argsv)
 		compdata_len = compbuf_len;
 		if (Z_OK != compress((Bytef *)compbuf, &compdata_len, (Bytef *)inbuf, (uLong)inlen) ) {
 			fprintf(stderr, "tid %d: compress error\n", tid);
-			return (void *) -1;					
+			return (void *) -1;
 		}
 	}
 
-	/* wait all threads to finish; min max not useful anymore since timer is after this barrier */	
-	pthread_barrier_wait(&barr);	
+	/* wait all threads to finish; min max not useful anymore since timer is after this barrier */
+	pthread_barrier_wait(&barr);
 
 	gettimeofday(&te, NULL);
 
-	elapsed = ((double) te.tv_sec + (double)te.tv_usec/1.0e6) 
+	elapsed = ((double) te.tv_sec + (double)te.tv_usec/1.0e6)
 		- ((double) ts.tv_sec + (double)ts.tv_usec/1.0e6);
 	argsp->elapsed_time = elapsed;
 
@@ -212,9 +212,9 @@ void *comp_file_multith(void *argsv)
 			tid, (long)inlen, iterations, elapsed);
 
 	free(decompbuf);
-	free(compbuf);		
-	
-	return (void *) -1;	
+	free(compbuf);
+
+	return (void *) -1;
 }
 
 
@@ -236,10 +236,10 @@ void *decomp_file_multith(void *argsv)
 #endif
 
 	inbuf = argsp->inbuf;
-	inlen = argsp->inlen;	
+	inlen = argsp->inlen;
 	iterations = argsp->iterations;
 	tid = argsp->my_id;
-	
+
 	compbuf_len = 2*inlen;
 	decompbuf_len = 2*inlen;
 
@@ -254,23 +254,23 @@ void *decomp_file_multith(void *argsv)
 	if (Z_OK != compress((Bytef *)compbuf, &compdata_len, (Bytef *)inbuf, (uLong)inlen) ) {
 		fprintf(stderr, "tid %d: compress error\n", tid);
 		return (void *) -1;
-	}	
+	}
 
 	/* wait all threads to finish their first runs; want this for pretty printing */
 	pthread_barrier_wait(&barr);
-	
+
 	/* uncompress */
 	decompdata_len = decompbuf_len;
 	/* decompdata_len is the buffer length before the call;
-	   returned as actual uncompressed data len on return */	
+	   returned as actual uncompressed data len on return */
 	if (Z_OK != uncompress((Bytef *)decompbuf, &decompdata_len, (Bytef *)compbuf, (uLong)compdata_len) ) {
 		fprintf(stderr, "uncompress error\n");
-		return (void *) -1;		
+		return (void *) -1;
 	}
 
-	/* wait all threads to finish their first runs; */	
+	/* wait all threads to finish their first runs; */
 	pthread_barrier_wait(&barr);
-	
+
 	/* TIMING RUNS start here; when we report bandwidth it's the
 	   larger of the input and output; for compress it is input
 	   size divided by time for decompress it is output size
@@ -281,7 +281,7 @@ void *decomp_file_multith(void *argsv)
 
 		decompdata_len = decompbuf_len;
 		/* decompdata_len is the buffer length before the call;
-		   returned as actual uncompressed data len on return */	
+		   returned as actual uncompressed data len on return */
 		if (Z_OK != uncompress((Bytef *)decompbuf, &decompdata_len, (Bytef *)compbuf, (uLong)compdata_len) ) {
 			fprintf(stderr, "tid %d: uncompress error\n", tid);
 			return (void *) -1;
@@ -289,21 +289,21 @@ void *decomp_file_multith(void *argsv)
 
 #ifdef SIMPLE_CHECKSUM
 
-		cksum = 1;		
+		cksum = 1;
 		cksum = crc32(cksum, decompbuf, decompdata_len);
 		assert( cksum == argsp->checksum );
 #endif
-		
+
 	}
 
 	/* wait all threads to finish; min max not useful anymore since timer is after this barrier */
 	pthread_barrier_wait(&barr);
-	
+
 	gettimeofday(&te, NULL);
 
 	elapsed = ((double) te.tv_sec + (double)te.tv_usec/1.0e6)
 		- ((double) ts.tv_sec + (double)ts.tv_usec/1.0e6);
-	argsp->elapsed_time = elapsed;	
+	argsp->elapsed_time = elapsed;
 
 	if (tid == 0)
 		fprintf(stderr, "tid %d: uncompressed to %ld bytes %ld times in %7.4g seconds\n",
@@ -314,11 +314,11 @@ void *decomp_file_multith(void *argsv)
 	cksum = crc32(cksum, decompbuf, decompdata_len);
 	assert( cksum == argsp->checksum );
 #endif
-	
-	free(decompbuf);
-	free(compbuf);		
 
-	return (void *) -1;	
+	free(decompbuf);
+	free(compbuf);
+
+	return (void *) -1;
 }
 
 #define MAX_THREADS 1024
@@ -329,18 +329,18 @@ int main(int argc, char **argv)
 	char *inbuf;
 	size_t inlen;
 	pthread_t threads[MAX_THREADS];
-	thread_args_t th_args[MAX_THREADS];	
+	thread_args_t th_args[MAX_THREADS];
 	int num_threads, i;
 	void *ret;
 	long iterations;
 	double sum;
-	
+
 	if (argc != 3 && argc != 4) {
 		fprintf(stderr, "usage: %s <fname> <thread_count> [<iterations>]\n", argv[0]);
 		exit(-1);
 	}
 	assert( (num_threads = atoi(argv[2])) <= MAX_THREADS);
-	
+
 	if (read_alloc_input_file(argv[1], &inbuf, &inlen))
 		exit(-1);
 	fprintf(stderr, "file %s read, %ld bytes\n", argv[1], inlen);
@@ -353,17 +353,17 @@ int main(int argc, char **argv)
 	else
 		iterations = 100;
 
-	unsigned long cksum = 1;	
+	unsigned long cksum = 1;
 #ifdef SIMPLE_CHECKSUM
-	cksum = crc32(cksum, inbuf, inlen);	
+	cksum = crc32(cksum, inbuf, inlen);
 	fprintf(stderr, "source checksum %08lx; note: checksum verif will reduce throughput; assert thrown on mismatch\n", cksum);
 #endif
-	
+
 	fprintf(stderr, "starting %d compress threads %ld iterations\n", num_threads, iterations);
 	for (i = 0; i < num_threads; i++) {
 		th_args[i].inbuf = inbuf;
 		th_args[i].inlen = inlen;
-		th_args[i].checksum = cksum;				
+		th_args[i].checksum = cksum;
 		th_args[i].my_id = i;
 		th_args[i].iterations = iterations;
 
@@ -395,15 +395,13 @@ int main(int argc, char **argv)
 		if (gbps > maxbw) maxbw = gbps;
 	}
 	fprintf(stderr, "\nTotal compress throughput GB/s %7.4g, bytes %ld, iterations %ld, threads %d, per thread maxbw %7.4g, minbw %7.4g\n\n",
-		sum, th_args[0].inlen, th_args[0].iterations, num_threads, maxbw, minbw);	
+		sum, th_args[0].inlen, th_args[0].iterations, num_threads, maxbw, minbw);
 
-
-	
 	fprintf(stderr, "starting %d uncompress threads\n", num_threads);
 	for (i = 0; i < num_threads; i++) {
 		th_args[i].inbuf = inbuf;
 		th_args[i].inlen = inlen;
-		th_args[i].checksum = cksum;						
+		th_args[i].checksum = cksum;
 		th_args[i].my_id = i;
 		th_args[i].iterations = iterations;
 
@@ -427,7 +425,7 @@ int main(int argc, char **argv)
 	/* report results */
 	sum = 0;
 	maxbw = 0;
-	minbw = 1.0e20;	
+	minbw = 1.0e20;
 	for (i=0; i < num_threads; i++) {
 		double gbps = (double)th_args[i].inlen * (double)th_args[i].iterations /
 			(double)th_args[i].elapsed_time / 1.0e9;
@@ -436,10 +434,7 @@ int main(int argc, char **argv)
 		if (gbps > maxbw) maxbw = gbps;
 	}
 	fprintf(stderr, "\nTotal uncompress throughput GB/s %7.4g, bytes %ld, iterations %ld, threads %d, per thread maxbw %7.4g, minbw %7.4g\n\n",
-		sum, th_args[0].inlen, th_args[0].iterations, num_threads, maxbw, minbw);	
-	
+		sum, th_args[0].inlen, th_args[0].iterations, num_threads, maxbw, minbw);
+
 	return rc;
 }
-
-
-


### PR DESCRIPTION
1. Fix typos causing the config file to not be properly parsed.
2. Remove unnecessary whitespaces from samples/compdecomp_th.c.
3. Fixes the default value for `CFLAGS`.