### PR TITLE
Update libz.abi to version 1.2.12

### DIFF
--- a/test/libz.abi
+++ b/test/libz.abi
@@ -13,6 +13,9 @@
     <elf-symbol name='crc32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='crc32_combine64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='crc32_combine' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_combine_gen64' version='ZLIB_1.2.12' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_combine_gen' version='ZLIB_1.2.12' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_combine_op' version='ZLIB_1.2.12' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='crc32_z' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='deflate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='deflateBound' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>

--- a/test/zlib.supp
+++ b/test/zlib.supp
@@ -1,5 +1,15 @@
 # List of zlib exported symbols currently not implemented by libnxz. These
 # must be ignored in our ABI comparison for now.
+
+[suppress_function]
+  symbol_name = crc32_combine_gen64
+
+[suppress_function]
+  symbol_name = crc32_combine_gen
+
+[suppress_function]
+  symbol_name = crc32_combine_op
+
 [suppress_function]
   symbol_name = deflateGetDictionary
 


### PR DESCRIPTION
A new zlib version has been released, and it includes some new symbols
that are not provided by libnxz at the moment.

Signed-off-by: Matheus Castanho <msc@linux.ibm.com>