### PR TITLE
Switch to software if NX is spending too much time in a job

### DIFF
--- a/lib/nx_compress.c
+++ b/lib/nx_compress.c
@@ -84,10 +84,13 @@ int compress2(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen
 	int rc=0;
 
 	if(nx_config.mode.deflate == GZIP_AUTO){
-		if(sourceLen <= COMPRESS_THRESHOLD)
+		if(sourceLen <= COMPRESS_THRESHOLD ||
+		   avg_delay > nx_config.compress_delay) {
 			rc = sw_compress2(dest, destLen, source, sourceLen, level);
-		else
+			decrease_delay();
+		} else {
 			rc = nx_compress2(dest, destLen, source, sourceLen, level);
+		}
 	}else if(nx_config.mode.deflate == GZIP_NX){
 		rc = nx_compress2(dest, destLen, source, sourceLen, level);
 	}else{

--- a/lib/nx_uncompr.c
+++ b/lib/nx_uncompr.c
@@ -93,10 +93,13 @@ int uncompress2(Bytef *dest, uLongf *destLen, const Bytef *source, uLong *source
 	int rc;
 
 	if(nx_config.mode.inflate == GZIP_AUTO){
-		if(*sourceLen <= DECOMPRESS_THRESHOLD)
+		if(*sourceLen <= DECOMPRESS_THRESHOLD ||
+		   avg_delay > nx_config.decompress_delay) {
+			decrease_delay();
 			rc = sw_uncompress2(dest, destLen, source, sourceLen);
-		else
+		} else {
 			rc = nx_uncompress2(dest, destLen, source, sourceLen);
+		}
 	}else if(nx_config.mode.inflate == GZIP_NX){
 		rc = nx_uncompress2(dest, destLen, source, sourceLen);
 	}else{
@@ -118,10 +121,13 @@ int uncompress(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLe
 	int rc=0;
 
 	if(nx_config.mode.inflate == GZIP_AUTO){
-		if(sourceLen <= DECOMPRESS_THRESHOLD)
+		if(sourceLen <= DECOMPRESS_THRESHOLD ||
+		   avg_delay > nx_config.decompress_delay) {
 			rc = sw_uncompress(dest, destLen, source, sourceLen);
-		else
+			decrease_delay();
+		} else {
 			rc = nx_uncompress(dest, destLen, source, sourceLen);
+		}
 	}else if(nx_config.mode.inflate == GZIP_NX){
 		rc = nx_uncompress(dest, destLen, source, sourceLen);
 	}else{

--- a/test/libnxz.abi
+++ b/test/libnxz.abi
@@ -654,7 +654,7 @@
         <var-decl name='deflate' type-id='b96825af' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='nx_config_t' size-in-bits='768' is-struct='yes' visibility='default' id='2c339f29'>
+    <class-decl name='nx_config_t' size-in-bits='896' is-struct='yes' visibility='default' id='2c339f29'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='page_sz' type-id='bd54fe1a' visibility='default'/>
       </data-member>
@@ -726,6 +726,12 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='752'>
         <var-decl name='virtualization' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='decompress_delay' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='compress_delay' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>
     <class-decl name='zlib_stats' size-in-bits='133056' is-struct='yes' visibility='default' id='3c1bf0d8'>
@@ -1005,6 +1011,8 @@
     <var-decl name='nx_dbg' type-id='95e97e5e' visibility='default'/>
     <var-decl name='mutex_log' type-id='7a6844eb' visibility='default'/>
     <var-decl name='nx_config' type-id='2c339f29' visibility='default'/>
+    <var-decl name='avg_delay' type-id='9c313c2d' visibility='default'/>
+    <var-decl name='nx_ticks_per_sec' type-id='9c313c2d' visibility='default'/>
     <var-decl name='zlib_stats_mutex' type-id='7a6844eb' visibility='default'/>
     <var-decl name='zlib_stats' type-id='3c1bf0d8' visibility='default'/>
     <function-decl name='zlibVersion' mangled-name='zlibVersion' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibVersion'>

--- a/test/nx-zlib.conf
+++ b/test/nx-zlib.conf
@@ -61,3 +61,17 @@ logfile = ./nx.log
 # Maximum number of times deflateInit/inflateInit can reuse an already-open VAS
 # window. Default: 10000
 # max_vas_reuse_count = 10000
+
+# Threshold in ticks to start using software compression/decompression
+# No default.
+#delay_threshold = 17000000
+
+# Delay threshold for compression. Is ignored if delay_threshold is also set.
+# Note: if the library is run on baremetal this value is multiplied by 3.
+# Default: 100000000
+#compress_delay = 100000000
+
+# Delay threshold for decompression. Is ignored if delay_threshold is also
+# set. Note: if the library is run on baremetal this value is multiplied by 3.
+# Default: 17000000
+#decompress_delay = 17000000


### PR DESCRIPTION
Measure the average time spent on NX jobs and fallback to software if it is greater than our threshold.
I'm keeping it as draft for now because I'm not sure which value should be used as threshold yet.
This seems to solve #152 as well.