### PR TITLE
Fix recent regressions in oct

### DIFF
--- a/oct/Makefile.am
+++ b/oct/Makefile.am
@@ -33,25 +33,25 @@ minigzip.c:
 	https://raw.githubusercontent.com/madler/zlib/master/test/$@
 
 .PRECIOUS: %.uncompressed
-empty.uncompressed:
+$(srcdir)/empty.uncompressed:
 	cd $(srcdir) && dd if=/dev/null bs=1k count=1 of=$@
 
-random4k.uncompressed:
+$(srcdir)/random4k.uncompressed:
 	cd $(srcdir) && dd if=/dev/urandom bs=4k count=1 of=$@
 
-random13M.uncompressed:
+$(srcdir)/random13M.uncompressed:
 	cd $(srcdir) && dd if=/dev/urandom bs=1M count=13 of=$@
 
-sparse10M.uncompressed:
+$(srcdir)/sparse10M.uncompressed:
 	cd $(srcdir) && dd if=/dev/urandom bs=1 count=0 seek=10M of=$@
 
-sparse1000M.uncompressed:
+$(srcdir)/sparse1000M.uncompressed:
 	cd $(srcdir) && dd if=/dev/urandom bs=1 count=0 seek=1000M of=$@
 
-zero4k.uncompressed:
+$(srcdir)/zero4k.uncompressed:
 	cd $(srcdir) && dd if=/dev/zero bs=4k count=1 of=$@
 
-zero13M.uncompressed:
+$(srcdir)/zero13M.uncompressed:
 	cd $(srcdir) && dd if=/dev/zero bs=1M count=13 of=$@
 
 
@@ -81,8 +81,8 @@ zero13M.uncompressed:
 
 # Pre-compute the checksum of all files in parallel.
 .PRECIOUS: %.checksum
-%.checksum: %.uncompressed
-	@$(SHA256SUM) $(srcdir)/$? | $(AWK) '{ print $1 }' > $@
+%.checksum: $(srcdir)/%.uncompressed
+	@$(SHA256SUM) $? | $(AWK) '{ print $$1 }' > $@
 
 check-am: all-am
 	$(MAKE) $(AM_MAKEFLAGS) $(check_PROGRAMS) $(check_SCRIPTS) \

--- a/oct/Makefile.am
+++ b/oct/Makefile.am
@@ -55,28 +55,27 @@ $(srcdir)/zero13M.uncompressed:
 	cd $(srcdir) && dd if=/dev/zero bs=1M count=13 of=$@
 
 
-
-%.uncompressed: %.source download.sh config.sh
+%.uncompressed: %.source | download.sh config.sh
 	cd $(srcdir) && CONFIG=${abs_builddir}/config.sh ./download.sh $*
 
 .PRECIOUS: %.compress.deflate %.decompress.deflate %.compdecomp.deflate
-%.compress.deflate.test: generate-test.sh config.sh minideflate
+%.compress.deflate.test: generate-test.sh config.sh minideflate $(check_FILES)
 	CONFIG=${abs_builddir}/config.sh $(srcdir)/generate-test.sh $@
 
-%.decompress.deflate.test: generate-test.sh config.sh minideflate
+%.decompress.deflate.test: generate-test.sh config.sh minideflate $(check_FILES)
 	CONFIG=${abs_builddir}/config.sh $(srcdir)/generate-test.sh $@
 
-%.compdecomp.deflate.test: generate-test.sh config.sh minideflate
+%.compdecomp.deflate.test: generate-test.sh config.sh minideflate $(check_FILES)
 	CONFIG=${abs_builddir}/config.sh $(srcdir)/generate-test.sh $@
 
 .PRECIOUS: %.compress.gzip %.decompress.gzip %.compdecomp.gzip
-%.compress.gzip.test: generate-test.sh config.sh minigzipsh
+%.compress.gzip.test: generate-test.sh config.sh minigzipsh $(check_FILES)
 	CONFIG=${abs_builddir}/config.sh $(srcdir)/generate-test.sh $@
 
-%.decompress.gzip.test: generate-test.sh config.sh minigzipsh
+%.decompress.gzip.test: generate-test.sh config.sh minigzipsh $(check_FILES)
 	CONFIG=${abs_builddir}/config.sh $(srcdir)/generate-test.sh $@
 
-%.compdecomp.gzip.test: generate-test.sh config.sh minigzipsh
+%.compdecomp.gzip.test: generate-test.sh config.sh minigzipsh $(check_FILES)
 	CONFIG=${abs_builddir}/config.sh $(srcdir)/generate-test.sh $@
 
 # Pre-compute the checksum of all files in parallel.

--- a/oct/Makefile.in
+++ b/oct/Makefile.in
@@ -1040,25 +1040,25 @@ minigzip.c:
 	https://raw.githubusercontent.com/madler/zlib/master/test/$@
 
 .PRECIOUS: %.uncompressed
-empty.uncompressed:
+$(srcdir)/empty.uncompressed:
 	cd $(srcdir) && dd if=/dev/null bs=1k count=1 of=$@
 
-random4k.uncompressed:
+$(srcdir)/random4k.uncompressed:
 	cd $(srcdir) && dd if=/dev/urandom bs=4k count=1 of=$@
 
-random13M.uncompressed:
+$(srcdir)/random13M.uncompressed:
 	cd $(srcdir) && dd if=/dev/urandom bs=1M count=13 of=$@
 
-sparse10M.uncompressed:
+$(srcdir)/sparse10M.uncompressed:
 	cd $(srcdir) && dd if=/dev/urandom bs=1 count=0 seek=10M of=$@
 
-sparse1000M.uncompressed:
+$(srcdir)/sparse1000M.uncompressed:
 	cd $(srcdir) && dd if=/dev/urandom bs=1 count=0 seek=1000M of=$@
 
-zero4k.uncompressed:
+$(srcdir)/zero4k.uncompressed:
 	cd $(srcdir) && dd if=/dev/zero bs=4k count=1 of=$@
 
-zero13M.uncompressed:
+$(srcdir)/zero13M.uncompressed:
 	cd $(srcdir) && dd if=/dev/zero bs=1M count=13 of=$@
 
 %.uncompressed: %.source download.sh config.sh
@@ -1086,8 +1086,8 @@ zero13M.uncompressed:
 
 # Pre-compute the checksum of all files in parallel.
 .PRECIOUS: %.checksum
-%.checksum: %.uncompressed
-	@$(SHA256SUM) $(srcdir)/$? | $(AWK) '{ print $1 }' > $@
+%.checksum: $(srcdir)/%.uncompressed
+	@$(SHA256SUM) $? | $(AWK) '{ print $$1 }' > $@
 
 check-am: all-am
 	$(MAKE) $(AM_MAKEFLAGS) $(check_PROGRAMS) $(check_SCRIPTS) \

--- a/oct/Makefile.in
+++ b/oct/Makefile.in
@@ -1061,27 +1061,27 @@ $(srcdir)/zero4k.uncompressed:
 $(srcdir)/zero13M.uncompressed:
 	cd $(srcdir) && dd if=/dev/zero bs=1M count=13 of=$@
 
-%.uncompressed: %.source download.sh config.sh
+%.uncompressed: %.source | download.sh config.sh
 	cd $(srcdir) && CONFIG=${abs_builddir}/config.sh ./download.sh $*
 
 .PRECIOUS: %.compress.deflate %.decompress.deflate %.compdecomp.deflate
-%.compress.deflate.test: generate-test.sh config.sh minideflate
+%.compress.deflate.test: generate-test.sh config.sh minideflate $(check_FILES)
 	CONFIG=${abs_builddir}/config.sh $(srcdir)/generate-test.sh $@
 
-%.decompress.deflate.test: generate-test.sh config.sh minideflate
+%.decompress.deflate.test: generate-test.sh config.sh minideflate $(check_FILES)
 	CONFIG=${abs_builddir}/config.sh $(srcdir)/generate-test.sh $@
 
-%.compdecomp.deflate.test: generate-test.sh config.sh minideflate
+%.compdecomp.deflate.test: generate-test.sh config.sh minideflate $(check_FILES)
 	CONFIG=${abs_builddir}/config.sh $(srcdir)/generate-test.sh $@
 
 .PRECIOUS: %.compress.gzip %.decompress.gzip %.compdecomp.gzip
-%.compress.gzip.test: generate-test.sh config.sh minigzipsh
+%.compress.gzip.test: generate-test.sh config.sh minigzipsh $(check_FILES)
 	CONFIG=${abs_builddir}/config.sh $(srcdir)/generate-test.sh $@
 
-%.decompress.gzip.test: generate-test.sh config.sh minigzipsh
+%.decompress.gzip.test: generate-test.sh config.sh minigzipsh $(check_FILES)
 	CONFIG=${abs_builddir}/config.sh $(srcdir)/generate-test.sh $@
 
-%.compdecomp.gzip.test: generate-test.sh config.sh minigzipsh
+%.compdecomp.gzip.test: generate-test.sh config.sh minigzipsh $(check_FILES)
 	CONFIG=${abs_builddir}/config.sh $(srcdir)/generate-test.sh $@
 
 # Pre-compute the checksum of all files in parallel.


### PR DESCRIPTION
1. Fix the dependencies on uncompressed files.
2. Avoid re-downloading files after configure.