### PR TITLE
Fix a few issues and add more files to oct

### DIFF
--- a/lib/sw_zlib.c
+++ b/lib/sw_zlib.c
@@ -176,41 +176,6 @@ int sw_uncompress2(Bytef *dest, uLongf *destLen, const Bytef *source, uLong *sou
 	return (* p_uncompress2)(dest, destLen, source, sourceLen);
 }
 
-static int (* p_gzclose)(gzFile file);
-int sw_gzclose(gzFile file)
-{
-	check_sym(p_gzclose, Z_STREAM_ERROR);
-	return (* p_gzclose)(file);
-}
-
-static gzFile (* p_gzopen)(const char * path, const char *mode);
-gzFile sw_gzopen(const char * path, const char *mode)
-{
-	check_sym(p_gzopen, NULL);
-	return (* p_gzopen)(path, mode);
-}
-
-static gzFile (* p_gzdopen)(int fd, const char *mode);
-gzFile sw_gzdopen(int fd, const char *mode)
-{
-	check_sym(p_gzdopen, NULL);
-	return (* p_gzdopen)(fd, mode);
-}
-
-static int (* p_gzread)(gzFile file, void *buf, unsigned len);
-int sw_gzread(gzFile file, void *buf, unsigned len)
-{
-	check_sym(p_gzread, Z_STREAM_ERROR);
-	return (* p_gzread)(file, buf, len);
-}
-
-static int (*p_gzwrite)(gzFile file, const void *buf, unsigned len);
-int sw_gzwrite (gzFile file, const void *buf, unsigned len)
-{
-	check_sym(p_gzwrite, Z_STREAM_ERROR);
-	return (* p_gzwrite)(file, buf, len);
-}
-
 static int (* p_inflateInit_)(z_streamp strm, const char *version, int stream_size);
 int sw_inflateInit_(z_streamp strm, const char *version, int stream_size)
 {
@@ -343,11 +308,6 @@ int sw_zlib_init(void)
 #if ZLIB_VERNUM >= 0x1290
 	register_sym(uncompress2);
 #endif
-	register_sym(gzclose);
-	register_sym(gzopen);
-	register_sym(gzdopen);
-	register_sym(gzread);
-	register_sym(gzwrite);
 	register_sym(inflateInit_);
 	register_sym(inflateInit2_);
 	register_sym(inflateReset);

--- a/oct/generate-source.sh
+++ b/oct/generate-source.sh
@@ -2,8 +2,6 @@
 # Generate *.source file from a URL.
 # e.g. ./generate-source.sh <URL> > example.source
 
-. config.sh
-
 url=${1}
 
 decompress()
@@ -16,9 +14,9 @@ type=""
 
 set -e
 f=$(mktemp)
-${WGET} -q -L "${url}" -O ${f}
+wget -q -L "${url}" -O ${f}
 
-case "$(${FILE} -bi ${f})" in
+case "$(file -bi ${f})" in
   "application/gzip"*) type="gzip";;
   "application/x-bzip2"*) type="bzip2";;
   "application/x-xz"*) type="xz";;
@@ -31,7 +29,7 @@ case ${type} in
   "xz")    decompress ${XZ}    ${f};;
 esac
 
-checksum=$(${SHA256SUM} ${f} | awk '{print $1}')
+checksum=$(sha256sum ${f} | awk '{print $1}')
 rm ${f}
 
 echo "${url}"

--- a/oct/snappy-alice29.source
+++ b/oct/snappy-alice29.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/alice29.txt
+none
+sha256 7467306ee0feed4971260f3c87421154a05be571d944e9cb021a5713700c38f0

--- a/oct/snappy-asyoulik.source
+++ b/oct/snappy-asyoulik.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/asyoulik.txt
+none
+sha256 eaa3526fe53859f34ecdf255712f9ecf0b2c903451d4755b2edaa2e2599cb0fc

--- a/oct/snappy-baddata1.source
+++ b/oct/snappy-baddata1.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/baddata1.snappy
+none
+sha256 ca84adbcd5b4b784c3405fcdd4fa88f88a6614f2d5e5d4a527838785f1806623

--- a/oct/snappy-baddata2.source
+++ b/oct/snappy-baddata2.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/baddata2.snappy
+none
+sha256 06f0ca34f0de885d6a849e1c8df95391d4494bf430d3784ea2167113d6ca8947

--- a/oct/snappy-baddata3.source
+++ b/oct/snappy-baddata3.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/baddata3.snappy
+none
+sha256 2f60f8c9b5f3b9b0e3b4ff9aef983946552cdd1fdecdfad122292882894163bd

--- a/oct/snappy-fireworks.source
+++ b/oct/snappy-fireworks.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/fireworks.jpeg
+none
+sha256 93b986ce7d7e361f0d3840f9d531b5f40fb6ca8c14d6d74364150e255f126512

--- a/oct/snappy-geo-protodata.source
+++ b/oct/snappy-geo-protodata.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/geo.protodata
+none
+sha256 7c2875cd6d06c954240ba644618d1e1f2a167e4541731f019de5b4c1f8080f24

--- a/oct/snappy-html.source
+++ b/oct/snappy-html.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/html
+none
+sha256 5912445a6d50df1079f022d7e01fa615f5d128d53bad88acbf4f49e62a7ea759

--- a/oct/snappy-html_x_4.source
+++ b/oct/snappy-html_x_4.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/html_x_4
+none
+sha256 ce3b0ceece9a0c0f66a352fd65b87a8e06357b136e99a2a85fcb3b0689ff6671

--- a/oct/snappy-kppkn-gtb.source
+++ b/oct/snappy-kppkn-gtb.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/kppkn.gtb
+none
+sha256 1df7e44e4ec9bad952e7716fbdba0a2208665091866ded43407d03ed9ce23c24

--- a/oct/snappy-lcet10.source
+++ b/oct/snappy-lcet10.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/lcet10.txt
+none
+sha256 5314ba1dbb03f471df88bec6cd120a938ef60d0fd3511c5c1dce61bf7463245f

--- a/oct/snappy-paper-100k-pdf.source
+++ b/oct/snappy-paper-100k-pdf.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/paper-100k.pdf
+none
+sha256 60f73a051b7ca35bfec44734b2eed7736cb5c0b7f728beb7b97ade6c5e44849b

--- a/oct/snappy-plrabn12.source
+++ b/oct/snappy-plrabn12.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/plrabn12.txt
+none
+sha256 07e2e0b461af78c7c647cb53dab39de560198e16f799b4516eccf0fbd69f764c

--- a/oct/snappy-urls-10k.source
+++ b/oct/snappy-urls-10k.source
@@ -1,0 +1,3 @@
+https://github.com/google/snappy/raw/main/testdata/urls.10K
+none
+sha256 0319ce7fe1f51b14eace3de879fe7da15418d1525d3176c2b26c5985943a3cad

--- a/oct/tests.mk
+++ b/oct/tests.mk
@@ -21,6 +21,20 @@ source_files = at \
 	       silesia-webster \
 	       silesia-xml \
 	       silesia-x-ray \
+	       snappy-alice29 \
+	       snappy-asyoulik \
+	       snappy-baddata1 \
+	       snappy-baddata2 \
+	       snappy-baddata3 \
+	       snappy-fireworks \
+	       snappy-geo-protodata \
+	       snappy-html \
+	       snappy-html_x_4 \
+	       snappy-kppkn-gtb \
+	       snappy-lcet10 \
+	       snappy-paper-100k-pdf \
+	       snappy-plrabn12 \
+	       snappy-urls-10k \
 	       vmlinux
 
 # Do not enable large files by default.

--- a/test/test_gz.c
+++ b/test/test_gz.c
@@ -163,7 +163,7 @@ int main()
 	remove(filename);
 	memset(uncompr, 0, uncompr_len);
 
-	printf("Testing nx_gzwread...\n");
+	printf("Testing nx_gzread...\n");
 	if(test_gzwrite(src, src_len, filename))
 		goto err;
 	if(test_nx_gzread(src, uncompr, src_len, filename))


### PR DESCRIPTION
While I was integrating the oct files to snappy, I identified a few issues:

The first 2 patches fix small issues.
The 3rd patch rewrites gzread and make the 4th patch possible.
The 4th patch fix an issue where SW and NX functions were used for the same stream.
5th patch removes functions that became obsolete after the 4th patch.
Finally, the 6th patch add the new files to oct.