### PR TITLE
Test nx_deflateBound() instead of deflateBound()

### DIFF
--- a/test/deflate/z_finish.c
+++ b/test/deflate/z_finish.c
@@ -25,7 +25,7 @@ static int _test_nx_deflatef(Byte* src, unsigned int src_len, Byte* compr,
 	c_stream.next_in  = (z_const unsigned char *)src;
 	c_stream.next_out = compr;
 
-	bound = deflateBound(&c_stream, src_len);
+	bound = nx_deflateBound(&c_stream, src_len);
 
 	c_stream.avail_in = src_len;
 	c_stream.avail_out = compr_len;

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -137,7 +137,7 @@ int _test_nx_deflate(Byte* src, unsigned int src_len, Byte* compr,
 	if (time != NULL)
 		gettimeofday(&time->start, NULL);
 
-	bound = deflateBound(&c_stream, src_len);
+	bound = nx_deflateBound(&c_stream, src_len);
 
 	while (c_stream.total_in != src_len
 	       && c_stream.total_out < *compr_len) {


### PR DESCRIPTION
Fixes commit 84239c65fb69f4838eabbff66f5a1106d73f15dc by calling
nx_deflateBound() instead of deflateBound() in NX functions.

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>