### PR TITLE
Change how the length threshold is used

### DIFF
--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -1648,7 +1648,8 @@ int nx_deflate(z_streamp strm, int flush)
 		return Z_STREAM_ERROR;
 
 	/* check for sw deflate first */
-	if( (has_nx_state(strm)) && s->switchable && (0 == use_nx_deflate(strm))){
+	if (has_nx_state(strm) && s->switchable
+	    && (0 == use_nx_deflate(strm, flush))) {
 		/* Use software zlib, switch the sw and hw state */
 		nx_switch_to_sw(strm);
 
@@ -2005,8 +2006,8 @@ int nx_deflateSetDictionary(z_streamp strm, const unsigned char *dictionary, uns
 		return Z_STREAM_ERROR;
 
 	/* check for sw deflate first */
-	if ((has_nx_state(strm)) && s->switchable &&
-	    (0 == use_nx_deflate(strm))) {
+	if (has_nx_state(strm) && s->switchable &&
+	    (0 == use_nx_deflate(strm, Z_OK))) {
 		/* Use software zlib, switch the sw and hw state */
 		nx_switch_to_sw(strm);
 

--- a/lib/nx_gzlib.c
+++ b/lib/nx_gzlib.c
@@ -184,7 +184,10 @@ gzFile __gzopen(const char* path, int fd, const char *mode, int force_nx)
 
 		is_deflate = true;
 	} else {
-		err = nx_inflateInit(stream);
+		if (force_nx)
+			err = nx_inflateInit(stream);
+		else
+			err = inflateInit(stream);
 		is_deflate = false;
 		if (err == Z_OK) {
 			state->buf = malloc(BUF_LEN);

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -284,7 +284,8 @@ int nx_inflate(z_streamp strm, int flush)
 	if (s == NULL) return Z_STREAM_ERROR;
 
 	/* check for sw deflate first*/
-	if(has_nx_state(strm) && s->switchable && (0 == use_nx_inflate(strm))){
+	if (has_nx_state(strm) && s->switchable
+	    && (0 == use_nx_inflate(strm, flush))) {
 		/*Use software zlib, switch the sw and hw state*/
 		s = (nx_streamp) strm->state;
 		s->switchable = 0; /* decided to use sw zlib and not switchable */


### PR DESCRIPTION
1. Avoid falling back to software due to length threshold unless `Z_FINISH` is passed to `deflate()`/`inflate()`.
2. Fix an issue that was causing `gzopen()` to never fall-back to software.