### PR TITLE
Correctly handle suspension of shared windows

### DIFF
--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -497,6 +497,7 @@ int nx_submit_job(nx_dde_t *src, nx_dde_t *dst, nx_gzip_crb_cpb_t *cmdp, nx_devp
 
 static inline void nx_device_free(nx_devp_t nx_devp) {
 	nx_function_end(nx_devp);
+	pthread_rwlock_destroy(&nx_devp->rwlock);
 	free(nx_devp);
 }
 
@@ -597,9 +598,13 @@ nx_devp_t nx_open(int nx_id)
 	}
 
 success:
+	nx_devp->generation = 0;
+
 	/* This will help us identify when DLPAR core add/remove operations have
 	   happened */
 	nx_devp->init_total_credits = total_credits;
+
+	(void) pthread_rwlock_init(&nx_devp->rwlock, NULL);
 
 	if (nx_config.max_vas_reuse_count > 0) {
 		nx_devp->open_cnt = 1;  /* newly allocated nx_devp, so single

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -185,6 +185,9 @@ struct nx_dev_t {
 	void *paste_addr;  /* address used to send requests using paste insn */
 	int fd;            /* VAS window file descriptor */
 	int function;      /* NX function code */
+	pthread_rwlock_t rwlock; /* rwlock to sync shared use of this handle */
+	int generation;    /* counter of how many times this window has been
+			      (re)allocated */
 };
 typedef struct nx_dev_t *nx_devp_t;
 #define NX_DEVICES_MAX 256

--- a/test/serial-tests/Makefile.am
+++ b/test/serial-tests/Makefile.am
@@ -6,14 +6,18 @@ LDADD = ../../lib/libnxz.la $(PTHREAD_LIBS) -ldl
 # they need to be run serially
 .NOTPARALLEL:
 
-TESTS = test_exhaust_credits test_window_suspend
+TESTS = test_exhaust_credits test_window_suspend test_shared_window_suspend
 
-check_PROGRAMS = exhaust_credits exhaust_credits_nx test_window_suspend
+check_PROGRAMS = exhaust_credits exhaust_credits_nx test_window_suspend \
+                 test_shared_window_suspend
 
 exhaust_credits_SOURCES = exhaust_credits.c credit_utils.c ../test_utils.c
 exhaust_credits_nx_SOURCES = exhaust_credits.c credit_utils.c ../test_utils.c
 exhaust_credits_nx_CPPFLAGS = -DWITHPREFIX
 
 test_window_suspend_SOURCES = test_window_suspend.c credit_utils.c ../test_utils.c
+
+test_shared_window_suspend_SOURCES = test_shared_window_suspend.c credit_utils.c \
+                                     ../test_utils.c
 
 test_exhaust_credits: exhaust_credits exhaust_credits_nx

--- a/test/serial-tests/Makefile.in
+++ b/test/serial-tests/Makefile.in
@@ -88,9 +88,11 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 target_triplet = @target@
-TESTS = test_exhaust_credits test_window_suspend$(EXEEXT)
+TESTS = test_exhaust_credits test_window_suspend$(EXEEXT) \
+	test_shared_window_suspend$(EXEEXT)
 check_PROGRAMS = exhaust_credits$(EXEEXT) exhaust_credits_nx$(EXEEXT) \
-	test_window_suspend$(EXEEXT)
+	test_window_suspend$(EXEEXT) \
+	test_shared_window_suspend$(EXEEXT)
 subdir = test/serial-tests
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_compile_flag.m4 \
@@ -126,6 +128,14 @@ exhaust_credits_nx_OBJECTS = $(am_exhaust_credits_nx_OBJECTS)
 exhaust_credits_nx_LDADD = $(LDADD)
 exhaust_credits_nx_DEPENDENCIES = ../../lib/libnxz.la \
 	$(am__DEPENDENCIES_1)
+am_test_shared_window_suspend_OBJECTS =  \
+	test_shared_window_suspend.$(OBJEXT) credit_utils.$(OBJEXT) \
+	../test_utils.$(OBJEXT)
+test_shared_window_suspend_OBJECTS =  \
+	$(am_test_shared_window_suspend_OBJECTS)
+test_shared_window_suspend_LDADD = $(LDADD)
+test_shared_window_suspend_DEPENDENCIES = ../../lib/libnxz.la \
+	$(am__DEPENDENCIES_1)
 am_test_window_suspend_OBJECTS = test_window_suspend.$(OBJEXT) \
 	credit_utils.$(OBJEXT) ../test_utils.$(OBJEXT)
 test_window_suspend_OBJECTS = $(am_test_window_suspend_OBJECTS)
@@ -152,6 +162,7 @@ am__depfiles_remade = ../$(DEPDIR)/exhaust_credits_nx-test_utils.Po \
 	./$(DEPDIR)/exhaust_credits.Po \
 	./$(DEPDIR)/exhaust_credits_nx-credit_utils.Po \
 	./$(DEPDIR)/exhaust_credits_nx-exhaust_credits.Po \
+	./$(DEPDIR)/test_shared_window_suspend.Po \
 	./$(DEPDIR)/test_window_suspend.Po
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
@@ -173,9 +184,12 @@ am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
 am__v_CCLD_1 = 
 SOURCES = $(exhaust_credits_SOURCES) $(exhaust_credits_nx_SOURCES) \
+	$(test_shared_window_suspend_SOURCES) \
 	$(test_window_suspend_SOURCES)
 DIST_SOURCES = $(exhaust_credits_SOURCES) \
-	$(exhaust_credits_nx_SOURCES) $(test_window_suspend_SOURCES)
+	$(exhaust_credits_nx_SOURCES) \
+	$(test_shared_window_suspend_SOURCES) \
+	$(test_window_suspend_SOURCES)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -563,6 +577,9 @@ exhaust_credits_SOURCES = exhaust_credits.c credit_utils.c ../test_utils.c
 exhaust_credits_nx_SOURCES = exhaust_credits.c credit_utils.c ../test_utils.c
 exhaust_credits_nx_CPPFLAGS = -DWITHPREFIX
 test_window_suspend_SOURCES = test_window_suspend.c credit_utils.c ../test_utils.c
+test_shared_window_suspend_SOURCES = test_shared_window_suspend.c credit_utils.c \
+                                     ../test_utils.c
+
 all: all-am
 
 .SUFFIXES:
@@ -624,6 +641,10 @@ exhaust_credits_nx$(EXEEXT): $(exhaust_credits_nx_OBJECTS) $(exhaust_credits_nx_
 	@rm -f exhaust_credits_nx$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(exhaust_credits_nx_OBJECTS) $(exhaust_credits_nx_LDADD) $(LIBS)
 
+test_shared_window_suspend$(EXEEXT): $(test_shared_window_suspend_OBJECTS) $(test_shared_window_suspend_DEPENDENCIES) $(EXTRA_test_shared_window_suspend_DEPENDENCIES) 
+	@rm -f test_shared_window_suspend$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(test_shared_window_suspend_OBJECTS) $(test_shared_window_suspend_LDADD) $(LIBS)
+
 test_window_suspend$(EXEEXT): $(test_window_suspend_OBJECTS) $(test_window_suspend_DEPENDENCIES) $(EXTRA_test_window_suspend_DEPENDENCIES) 
 	@rm -f test_window_suspend$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_window_suspend_OBJECTS) $(test_window_suspend_LDADD) $(LIBS)
@@ -641,6 +662,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/exhaust_credits.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/exhaust_credits_nx-credit_utils.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/exhaust_credits_nx-exhaust_credits.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_shared_window_suspend.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_window_suspend.Po@am__quote@ # am--include-marker
 
 $(am__depfiles_remade):
@@ -928,6 +950,13 @@ test_window_suspend.log: test_window_suspend$(EXEEXT)
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test_shared_window_suspend.log: test_shared_window_suspend$(EXEEXT)
+	@p='test_shared_window_suspend$(EXEEXT)'; \
+	b='test_shared_window_suspend'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 .test.log:
 	@p='$<'; \
 	$(am__set_b); \
@@ -1029,6 +1058,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/exhaust_credits.Po
 	-rm -f ./$(DEPDIR)/exhaust_credits_nx-credit_utils.Po
 	-rm -f ./$(DEPDIR)/exhaust_credits_nx-exhaust_credits.Po
+	-rm -f ./$(DEPDIR)/test_shared_window_suspend.Po
 	-rm -f ./$(DEPDIR)/test_window_suspend.Po
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
@@ -1081,6 +1111,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/exhaust_credits.Po
 	-rm -f ./$(DEPDIR)/exhaust_credits_nx-credit_utils.Po
 	-rm -f ./$(DEPDIR)/exhaust_credits_nx-exhaust_credits.Po
+	-rm -f ./$(DEPDIR)/test_shared_window_suspend.Po
 	-rm -f ./$(DEPDIR)/test_window_suspend.Po
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic

--- a/test/serial-tests/credit_utils.h
+++ b/test/serial-tests/credit_utils.h
@@ -6,6 +6,15 @@
 extern pid_t *children;
 extern int num_procs;
 
+/* Run shell command */
+int run(const char *command);
+
+/* Reduce credits in the system by executing a DLPAR remove core operation */
+int reduce_credits(void);
+
+/* Restore credits in the system by executing a DLPAR add core operation */
+void restore_credits(void);
+
 /* Read credits information from sysfs */
 int read_credits(int *total, int *used);
 

--- a/test/serial-tests/test_shared_window_suspend.c
+++ b/test/serial-tests/test_shared_window_suspend.c
@@ -1,0 +1,186 @@
+/* Test libnxz behavior when windows are suspended due to a DLPAR operation.
+
+   Test outline:
+   - Consume N-3 credits by calling deflateInit from N-3 child processes
+   - Start 2 threads and call deflateInit from them (window shared, 1 credit spent)
+   - Force a DLPAR core remove operation to remove 3 credits from the system
+   - The window shared by both threads will be suspended and the system
+     oversubscribed by 1 credit.
+   - Release 1 credit by finishing a process with an active window
+   - Now the threads should be able to get a new window and finish execution
+     successfully.
+*/
+#define _GNU_SOURCE /* For pthread_tryjoin_np */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/fcntl.h>
+#include <sys/mman.h>
+#include <endian.h>
+#include <bits/endian.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <assert.h>
+#include <errno.h>
+#include <signal.h>
+#include <pthread.h>
+
+#include "test.h"
+#include "test_utils.h"
+#include "credit_utils.h"
+
+Bytef *src, *compr;
+const unsigned int src_len = 32000; 	/* Need something larger than
+					   cache_threshold to avoid deflate
+					   falling back to software by
+					   default. */
+const unsigned int compr_len = 64000;
+
+pthread_barrier_t barrier;
+
+void child_do(void) {
+
+}
+
+void* run_thread(void* args) {
+	z_stream stream;
+	int rc;
+
+	stream.zalloc = NULL;
+	stream.zfree = NULL;
+	stream.opaque = (voidpf)0;
+
+	if (deflateInit(&stream, Z_DEFAULT_COMPRESSION) != Z_OK) {
+		fprintf(stderr, "[%d] Failed to allocate credit!\n",
+			getpid());
+		exit(-1);
+	}
+
+	pthread_barrier_wait(&barrier);
+
+	stream.next_in = src;
+	stream.avail_in = src_len;
+	stream.next_out = compr;
+	stream.avail_out = compr_len;
+
+	rc = deflate(&stream, Z_FINISH);
+	if (rc != Z_STREAM_END) {
+		fprintf(stderr, "deflate failed! rc = %s\n", zret2str(rc));
+		exit(1);
+	}
+
+	return (void*) 0;
+}
+
+int main(int argc, char** argv)
+{
+	int total_credits, used_credits;
+	pthread_t threads[2];
+	void* retval;
+
+	/* The credit system is only used by PowerVM. So skip otherwise. */
+	if (!is_powervm())
+		return TEST_SKIP;
+
+	/* Need to be root to run drmgr */
+	if (geteuid() != 0) {
+		fprintf(stderr, "This test needs to be run as root.\n");
+		return TEST_SKIP;
+	}
+
+	generate_random_data(src_len);
+	src = (Byte*)&ran_data[0];
+
+	compr = (Byte*)calloc((uInt)compr_len, 1);
+	if (compr == NULL) {
+		printf("*** alloc buffer failed\n");
+		return TEST_ERROR;
+	}
+
+	if (read_credits(&total_credits, &used_credits))
+		return TEST_ERROR;
+	fprintf(stderr, "Credits before:  total: %d  used: %d\n", total_credits,
+		used_credits);
+
+	/* Leave 3 credits left. If we only leave 1 credit, the threads won't be
+	   able to open a new window. If we leave 2, the first one will allocate
+	   a VAS window but the second will fallback to software because the N-1
+	   limit has been reached and window reused will be disabled. */
+	num_procs = total_credits - used_credits - 3;
+	if (consume_credits(num_procs))
+		return TEST_ERROR;
+
+	if (read_credits(&total_credits, &used_credits))
+		return TEST_ERROR;
+	fprintf(stderr, "Credits after proc creation:  total: %d  used: %d\n", total_credits,
+		used_credits);
+
+	pthread_barrier_init(&barrier, NULL, 3);
+
+	/* All threads will share the same window, spending only 1 credit */
+	for (int i = 0; i < 2; i++) {
+		int rc = pthread_create(&threads[i], NULL, run_thread, NULL);
+		if (rc) {
+			fprintf(stderr, "Failed to create threads.\n");
+			return TEST_ERROR;
+		}
+	}
+
+	reduce_credits();
+	atexit(restore_credits);
+
+	if (read_credits(&total_credits, &used_credits))
+		return TEST_ERROR;
+	fprintf(stderr, "Credits after DLPAR:  total: %d  used: %d\n", total_credits,
+		used_credits);
+
+	/* Allow threads to start compression. Their windows are suspended, so
+	   they should start the backoff mechanism */
+	pthread_barrier_wait(&barrier);
+
+	/* Give them some time to realize their windows are suspended */
+	usleep(1000);
+
+	/* Verify both threads have not terminated, since they should be stuck
+	   trying to open a new window */
+	void *ret1=0, *ret2=0;
+	if (!pthread_tryjoin_np(threads[0], &ret1) ||
+	    !pthread_tryjoin_np(threads[1], &ret2)) {
+		fprintf(stderr, "Threads finished unexpectedly. ret1=%ld ret2=%ld\n",
+			(long)ret1, (long)ret2);
+		return TEST_ERROR;
+	}
+
+	/* The system is now 1 credit oversubscribed, so allow 1 process to
+	   continue so we leave 1 free credit to help the 2 threads recover */
+	pid_t proc = children[num_procs-1];
+	kill(proc, SIGUSR1);
+
+	if (waitpid(proc, NULL, 0) != proc) {
+		fprintf(stderr, "Unclean exit from process: %d\n", proc);
+		return TEST_ERROR;
+	}
+
+	int result = TEST_OK;
+	for (int i = 0; i < 2; i++) {
+		int rc;
+		rc = pthread_join(threads[i], &retval);
+		if (rc != 0 || (long)retval != 0) {
+			fprintf(stderr, "Thread %ld didn't finish correctly! ret = %ld\n",
+				threads[i], (long) retval);
+			result = TEST_ERROR;
+		}
+	}
+
+	printf("*** %s passed\n", __FILE__);
+	free(compr);
+	return result;
+}

--- a/test/serial-tests/test_window_suspend.c
+++ b/test/serial-tests/test_window_suspend.c
@@ -34,43 +34,12 @@
 #include "test_utils.h"
 #include "credit_utils.h"
 
-#define CPU_ARGS "-c cpu -w 5 -d 3"
-
 Bytef *src, *compr;
 const unsigned int src_len = 32000; 	/* Need something larger than
 					   cache_threshold to avoid deflate
 					   falling back to software by
 					   default. */
 const unsigned int compr_len = 64000;
-
-/* TODO: calling system with super-user privileges is not recommended, implement
-   our own version using fork, exec and wait instead. */
-int run(const char *command)
-{
-	return system(command);
-}
-
-/* For some reason the number of credits only changes when we alter the number
-   of virtual processors, even though on shared LPAR they are tied to the number
-   of processing units (aka Entitled Capactity). Remember credits=proc_units*20,
-   and drmgr sees 0.01 proc_units as 1 ent_capacity, so reducing ent_capacity by
-   5 means removing 0.05 units, and thus 1 credit. */
-#define PROC_UNITS "15" // -3 credits
-#define CPU_COUNT "1"
-
-int reduce_credits(void)
-{
-	run("drmgr " CPU_ARGS " -r -p ent_capacity -q " PROC_UNITS);
-	run("drmgr " CPU_ARGS " -r -q " CPU_COUNT);
-
-	return 0;
-}
-
-void restore_credits(void)
-{
-	(void) run("drmgr " CPU_ARGS " -a -p ent_capacity -q " PROC_UNITS);
-	(void) run("drmgr " CPU_ARGS " -a -q " CPU_COUNT);
-}
 
 /* Work for the child */
 void child_do(z_stream *stream) {


### PR DESCRIPTION
This PR is intended to fix the following issue:
https://github.com/libnxz/power-gzip/blob/3d08904a072d76f80a6229cb94847a43fc3fe58a/lib/gzip_vas.c#L371-L372

When libnxz suspects a VAS window might be suspended, it tries to open a
new one. But since the kernel does not allow the creation of new windows
while there are still suspended ones, libnxz has to close its existing
window before opening the new one.

This causes problems when a window is shared by multiple threads,
because one thread may issue a paste request on the window's associated
memory address, but it may not be valid anymore because a parallel
thread has already munmap'd it.

To avoid this problem every window now has a read-write lock and threads
are required to lock it first before performing any action on the
window, like reopening it or issuing a paste.

I ran `compdecomp_th` on PowerVM (100 threads) and baremetal (1000 threads) and couldn't detect any significant performance penalty.