### PR TITLE
Stop to subtract from total_in in nx_inflate()

### DIFF
--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -38,7 +38,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdint.h>

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -1732,8 +1732,6 @@ offsets_state:
 
 		/* copy trailer bytes to temp storage */
 		nx_inflate_verify_checksum(s, 1);
-		/* update total_in */
-		s->total_in = s->total_in - s->used_in; /* garbage past cksum ????? */
 		s->is_final = 1;
 		/* s->used_in = 0; */
 		if (s->used_out == 0) {

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -43,7 +43,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdint.h>

--- a/lib/sw_zlib.c
+++ b/lib/sw_zlib.c
@@ -39,7 +39,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdint.h>


### PR DESCRIPTION
Partially fix issue #181 by stopping to subtract from total_in in
nx_inflate().  total_in and total_out should always increase or be left
unchanged during deflate/inflate calls.

Also add tests to validate the values of:
 - avail_in
 - avail_out
 - next_in
 - next_out
 - total_in
 - total_out

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>