### PR TITLE
React better to partition migrations

### DIFF
--- a/lib/gzip_vas.c
+++ b/lib/gzip_vas.c
@@ -90,7 +90,6 @@
    before checking if VAS window may be suspended. */
 #define SUSPENDED_TIME_THRESHOLD (nx_get_freq() >> 5)
 
-void *nx_fault_storage_address;
 uint64_t tb_freq=0;
 
 static const uint64_t timeout_seconds = 60;
@@ -275,11 +274,6 @@ static int nx_wait_for_csb( nx_gzip_crb_cpb_t *cmdp )
 		if (t > (timeout_seconds * onesecond)) /* 1 min */
 			break;
 
-		/* fault address from signal handler */
-		if( nx_fault_storage_address ) {
-			return -EAGAIN;
-		}
-
 		hwsync();
 	} while (getnn( cmdp->crb.csb, csb_v ) == 0);
 
@@ -326,16 +320,6 @@ int nxu_run_job(nx_gzip_crb_cpb_t *cmdp, nx_devp_t nxhandle)
 
 			if (!ret) {
 				return ret;
-			}
-			else if (ret == -EAGAIN) {
-				volatile long x;
-				prt_err("Touching address %p, 0x%lx\n",
-					 nx_fault_storage_address,
-					 *(long *)nx_fault_storage_address);
-				x = *(long *)nx_fault_storage_address;
-				*(long *)nx_fault_storage_address = x;
-				nx_fault_storage_address = 0;
-				continue;
 			}
 			else {
 				prt_err("wait_for_csb() returns %d\n", ret);

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -587,7 +587,6 @@ extern unsigned long crc32_ppc(unsigned long crc, const unsigned char *buffer,
                                unsigned long len);
 
 /* gzip_vas.c */
-extern void *nx_fault_storage_address;
 extern int nx_function_begin(int function, int pri, nx_devp_t nxhandle);
 extern int nx_function_end(nx_devp_t nxhandle);
 extern uint64_t nx_wait_ticks(uint64_t ticks, uint64_t accumulated_ticks, int do_sleep);

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -165,7 +165,10 @@ struct nx_config_t {
 	/** time spent before fallbacking to sw */
 	uint64_t decompress_delay;
 	uint64_t compress_delay;
-
+	uint64_t timeout_wait_for_csb_v; /** Max time in seconds to wait for
+					  * CSB.V to become valid */
+	uint64_t timeout_paste_success;  /** Max time in seconds to wait for a
+					  * successful paste */
 };
 typedef struct nx_config_t *nx_configp_t;
 extern struct nx_config_t nx_config;


### PR DESCRIPTION
Partition migrations on PowerVM may take a few minutes, and during that
time libnxz will see consecutive paste failures, so we need to keep
waiting until the migration is complete. So use different timeouts for
waiting for a valid CSB and for a successful paste, giving PowerVM more
time on the paste case to properly handle migrations.

There's currently a bug in the kernel side in which the CSB might not
become valid for a long time during a migration unless we issue a new
paste. To work around it nx_submit_job has been changed to avoid a nasty
exit() call if nxu_run_job has returned with ETIMEDOUT. Instead, it now
just returns -1, triggering a job resubmission.