### PR TITLE
Make *Reset functions always restore NX state

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -202,7 +202,7 @@ ETAGS = etags
 CTAGS = ctags
 CSCOPE = cscope
 am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/aminclude.am \
-	$(srcdir)/config.h.in compile config.guess config.sub depcomp \
+	$(srcdir)/config.h.in compile config.guess config.sub \
 	install-sh ltmain.sh missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -13,6 +13,8 @@ libnxz_la_SOURCES = \
 		    crc32_ppc_constants.h \
 			crc32_power.c \
 		    gzip_vas.c \
+		    nx_map.c \
+		    nx_hash.h \
 		    nx_adler32.c \
 		    nx_compress.c \
 		    nx_crc.c \

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -136,9 +136,9 @@ LTLIBRARIES = $(lib_LTLIBRARIES)
 am__DEPENDENCIES_1 =
 libnxz_la_DEPENDENCIES = $(am__DEPENDENCIES_1)
 am_libnxz_la_OBJECTS = crc32_ppc.lo crc32_power.lo gzip_vas.lo \
-	nx_adler32.lo nx_compress.lo nx_crc.lo nx_deflate.lo nx_dht.lo \
-	nx_dhtgen.lo nx_dht_builtin.lo nx_gzlib.lo nx_inflate.lo \
-	nx_uncompr.lo nx_utils.lo nx_zlib.lo sw_zlib.lo
+	nx_map.lo nx_adler32.lo nx_compress.lo nx_crc.lo nx_deflate.lo \
+	nx_dht.lo nx_dhtgen.lo nx_dht_builtin.lo nx_gzlib.lo \
+	nx_inflate.lo nx_uncompr.lo nx_utils.lo nx_zlib.lo sw_zlib.lo
 libnxz_la_OBJECTS = $(am_libnxz_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -168,9 +168,9 @@ am__depfiles_remade = ./$(DEPDIR)/crc32_power.Plo \
 	./$(DEPDIR)/nx_crc.Plo ./$(DEPDIR)/nx_deflate.Plo \
 	./$(DEPDIR)/nx_dht.Plo ./$(DEPDIR)/nx_dht_builtin.Plo \
 	./$(DEPDIR)/nx_dhtgen.Plo ./$(DEPDIR)/nx_gzlib.Plo \
-	./$(DEPDIR)/nx_inflate.Plo ./$(DEPDIR)/nx_uncompr.Plo \
-	./$(DEPDIR)/nx_utils.Plo ./$(DEPDIR)/nx_zlib.Plo \
-	./$(DEPDIR)/sw_zlib.Plo
+	./$(DEPDIR)/nx_inflate.Plo ./$(DEPDIR)/nx_map.Plo \
+	./$(DEPDIR)/nx_uncompr.Plo ./$(DEPDIR)/nx_utils.Plo \
+	./$(DEPDIR)/nx_zlib.Plo ./$(DEPDIR)/sw_zlib.Plo
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
@@ -378,6 +378,8 @@ libnxz_la_SOURCES = \
 		    crc32_ppc_constants.h \
 			crc32_power.c \
 		    gzip_vas.c \
+		    nx_map.c \
+		    nx_hash.h \
 		    nx_adler32.c \
 		    nx_compress.c \
 		    nx_crc.c \
@@ -488,6 +490,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_dhtgen.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_gzlib.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_inflate.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_map.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_uncompr.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_utils.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nx_zlib.Plo@am__quote@ # am--include-marker
@@ -669,6 +672,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/nx_dhtgen.Plo
 	-rm -f ./$(DEPDIR)/nx_gzlib.Plo
 	-rm -f ./$(DEPDIR)/nx_inflate.Plo
+	-rm -f ./$(DEPDIR)/nx_map.Plo
 	-rm -f ./$(DEPDIR)/nx_uncompr.Plo
 	-rm -f ./$(DEPDIR)/nx_utils.Plo
 	-rm -f ./$(DEPDIR)/nx_zlib.Plo
@@ -730,6 +734,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/nx_dhtgen.Plo
 	-rm -f ./$(DEPDIR)/nx_gzlib.Plo
 	-rm -f ./$(DEPDIR)/nx_inflate.Plo
+	-rm -f ./$(DEPDIR)/nx_map.Plo
 	-rm -f ./$(DEPDIR)/nx_uncompr.Plo
 	-rm -f ./$(DEPDIR)/nx_utils.Plo
 	-rm -f ./$(DEPDIR)/nx_zlib.Plo

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -2115,6 +2115,40 @@ int inflateReset(z_streamp strm)
 }
 
 
+/** @brief Reset only the stream being used.
+
+    In zlib, inflateResetKeep() is an undocumented function.  The function is
+    not even listed in the Linux Standard Base Core Specification 3.2 [1].
+
+    In zlib, this function is used to reset inflate without resetting the
+    longest match structures.
+
+    So, one can argue this function is not useful for libnxz.
+    IBM's Z OS does not support it [2].
+
+    In order to provide some level of compatibility with zlib, it has been
+    decided this function will behave almost the same as inflateReset(), except
+    that it won't reset the stream being used, e.g. if a software stream has
+    been chosen, inflateResetKeep() will reset it, but won't reset the NX stream
+    and won't set the NX stream as the default one.
+    This behavior was chosen because it is compatible with zlib itself that
+    calls inflateResetKeep() from inflateReset() and expects that a zlib
+    stream (SW) is used upon returning from inflateResetKeep().
+
+    In theory, inflateResetKeep() could behave identically to inflateReset(),
+    but this would require that all calls to inflateResetKeep() from zlib go
+    directly to zlib's inflateResetKeep().  glibc's
+    dlmopen(LM_ID_NEWLM, RTLD_DEEPBIND) should help, but there appear to exist
+    bugs in glibc preventing it from working as designed.  These issues have
+    to be fixed and backported to supported distros before we can adopt this
+    behavior.
+
+    [1] https://refspecs.linuxfoundation.org/LSB_3.2.0/LSB-Core-generic/LSB-Core-generic/libzman.html
+    [2] https://www.ibm.com/docs/en/zos/2.3.0?topic=compression-standard-zlib-functions
+
+    @param strm A stream structure initialized by a call to inflateInit().
+    @return Z_OK in case of success and Z_STREAM_ERROR to indicate an error.
+*/
 int inflateResetKeep(z_streamp strm)
 {
 	if (has_nx_state(strm))

--- a/lib/nx_map.c
+++ b/lib/nx_map.c
@@ -1,0 +1,233 @@
+/* nx_map.c -- implement map data structure
+ *
+ * NX-GZIP compression accelerator user library
+ * implementing zlib compression library interfaces
+ *
+ * Copyright (C) IBM Corporation, 2022
+ *
+ * Licenses for GPLv2 and Apache v2.0:
+ *
+ * GPLv2:
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ *
+ * Apache v2.0:
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/** @file nx_map.c
+ * \brief Implement a basic map data structure to be used throughout libnxz.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <pthread.h>
+#include "nx_map.h"
+#include "nx_dbg.h"
+
+#define FNV_OFFSET 14695981039346656037UL
+#define FNV_PRIME 1099511628211UL
+
+#define MAP_INIT_SIZE 32
+
+typedef struct map_entry {
+	void *key;
+	void *val;
+} map_entry_t;
+
+struct map {
+	size_t size;
+	size_t nb_entries;
+	map_entry_t *array;
+	pthread_rwlock_t rwlock;
+};
+
+static size_t get_index(void *key, size_t array_size)
+{
+	/* Use 64-bit FNV-1a hashing algorithm to calculate the index
+	   https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function */
+	uint64_t hash = FNV_OFFSET;
+
+	for (int i = 0; i < sizeof(uintptr_t); i++) {
+		uint64_t byte = (((uint64_t)key) >> i) & 0xffUL;
+		hash ^= byte;
+		hash *= FNV_PRIME;
+	}
+	return (size_t)(hash % array_size);
+}
+
+nx_map_t* nx_map_init(void)
+{
+	nx_map_t *m;
+
+	m = malloc(sizeof(nx_map_t));
+	if (!m) {
+		prt_err("Failed to allocate map.\n");
+		return NULL;
+	}
+
+	m->array = calloc(MAP_INIT_SIZE, sizeof(map_entry_t));
+	if (!m->array) {
+		prt_err("Failed to allocate internal array for map.\n");
+		free(m);
+		return NULL;
+	}
+
+	m->size = MAP_INIT_SIZE;
+	m->nb_entries = 0;
+	pthread_rwlock_init(&m->rwlock, NULL);
+
+	return m;
+}
+
+int nx_map_destroy(nx_map_t *m) {
+	if (m == NULL)
+		return 0;
+
+	m->size = m->nb_entries = 0;
+	free(m->array);
+	pthread_rwlock_destroy(&m->rwlock);
+	free(m);
+
+	return 0;
+}
+
+int nx_map_get(nx_map_t *m, void *key, void **val)
+{
+	size_t i;
+	int ret = -1;
+
+	if (m == NULL || m->array == NULL) {
+		prt_err("Trying to access uninitialized map.\n");
+		return -1;
+	}
+
+	*val = 0;
+	i = get_index(key, m->size);
+
+	pthread_rwlock_rdlock(&m->rwlock);
+
+	for(int cnt = 0; cnt < m->size; cnt++) {
+		if (m->array[i].key == key) {
+			*val = m->array[i].val;
+			ret = 0;
+			break;
+		}
+
+		if (++i >= m->size)
+			i = 0; // wrap around
+	}
+
+	pthread_rwlock_unlock(&m->rwlock);
+
+	return ret;
+}
+
+static void insert_entry(nx_map_t *m, void *key, void *val)
+{
+	size_t i = get_index(key, m->size);
+
+	for (int cnt = 0; cnt < m->size; cnt++) {
+		if (m->array[i].key == NULL)
+			break;
+
+		if (++i >= m->size)
+			i = 0; // wrap around
+	}
+
+	m->array[i].key = key;
+	m->array[i].val = val;
+	m->nb_entries++;
+}
+
+static void rehash_entries(nx_map_t *m, map_entry_t *old_array, size_t old_size)
+{
+	for (size_t i = 0; i < old_size; i++)
+		if (old_array[i].key != NULL)
+			insert_entry(m, old_array[i].key, old_array[i].val);
+}
+
+int nx_map_put(nx_map_t *m, void* key, void* val)
+{
+	if (m == NULL || m->array == NULL) {
+		prt_err("Trying to alter uninitialized map.\n");
+		return -1;
+	}
+
+	pthread_rwlock_wrlock(&m->rwlock);
+
+	if (m->nb_entries >= m->size/2) {
+		size_t old_size = m->size;
+		map_entry_t *old_array = m->array;
+
+		m->size *= 2;
+		m->array = calloc(m->size, sizeof(map_entry_t));
+		if (m->array == NULL) {
+			prt_err("Failed to resize map\n");
+			m->array = old_array;
+			m->size = old_size;
+			pthread_rwlock_unlock(&m->rwlock);
+			return -1;
+		}
+
+		rehash_entries(m, old_array, old_size);
+	}
+
+	insert_entry(m, key, val);
+	pthread_rwlock_unlock(&m->rwlock);
+
+	return 0;
+}
+
+void* nx_map_remove(nx_map_t *m, void *key)
+{
+	void* val = NULL;
+
+	if (m == NULL || m->array == NULL) {
+		prt_err("Trying to access uninitialized map.\n");
+		return NULL;
+	}
+
+	size_t i = get_index(key, m->size);
+
+	pthread_rwlock_wrlock(&m->rwlock);
+
+	for(int cnt = 0; cnt < m->size; cnt++) {
+		if (m->array[i].key == key) {
+			val = m->array[i].val;
+			m->array[i].key = NULL;
+			m->array[i].val = NULL;
+			m->nb_entries--;
+			break;
+		}
+
+		if (++i >= m->size)
+			i = 0; // wrap around
+	}
+
+	pthread_rwlock_unlock(&m->rwlock);
+
+	return val;
+}

--- a/lib/nx_map.h
+++ b/lib/nx_map.h
@@ -1,0 +1,20 @@
+#ifndef NX_MAP_H
+#define NX_MAP_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct map nx_map_t;
+
+nx_map_t* nx_map_init(void);
+
+int nx_map_destroy(nx_map_t *h);
+
+int nx_map_get(nx_map_t *h, void *key, void **val);
+
+int nx_map_put(nx_map_t *h, void *key, void *val);
+
+void *nx_map_remove(nx_map_t *h, void *key);
+
+
+#endif

--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -122,6 +122,8 @@ pthread_mutex_t mutex_log;
 pthread_mutex_t zlib_stats_mutex; /* mutex to protect global stats */
 struct zlib_stats zlib_stats;	/* global statistics */
 
+__attribute__ ((visibility ("hidden"))) nx_map_t *stream_map = NULL;
+
 __attribute__ ((visibility ("hidden"))) uint64_t avg_delay = 0;
 uint64_t	nx_ticks_per_sec;
 
@@ -1319,6 +1321,12 @@ void nx_hw_init(void)
 		print_nx_config(nx_gzip_log);
 	}
 
+	stream_map = nx_map_init();
+	if (!stream_map) {
+		prt_err("Failed to initialize internal stream map\n");
+		return;
+	}
+
 	nx_close_cfg(&cfg_tab);
 	nx_init_done = 1;
 	prt_warn("libnxz loaded\n");
@@ -1348,6 +1356,8 @@ void nx_hw_done(void)
 		nx_gzip_log = NULL;
 	}
 	pthread_mutex_destroy(&saved_nx_devp_mutex);
+
+	(void) nx_map_destroy(stream_map);
 }
 
 static void _nx_hwdone(void) __attribute__((destructor));

--- a/ltmain.sh
+++ b/ltmain.sh
@@ -2124,7 +2124,7 @@ fi
 # a configuration failure hint, and exit.
 func_fatal_configuration ()
 {
-    func_fatal_error ${1+"$@"} \
+    func__fatal_error ${1+"$@"} \
       "See the $PACKAGE documentation for more information." \
       "Fatal configuration error."
 }
@@ -2415,17 +2415,10 @@ libtool_validate_options ()
     # preserve --debug
     test : = "$debug_cmd" || func_append preserve_args " --debug"
 
-    case $host in
-      # Solaris2 added to fix http://debbugs.gnu.org/cgi/bugreport.cgi?bug=16452
-      # see also: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=59788
-      *cygwin* | *mingw* | *pw32* | *cegcc* | *solaris2* | *os2*)
-        # don't eliminate duplications in $postdeps and $predeps
-        opt_duplicate_compiler_generated_deps=:
-        ;;
-      *)
-        opt_duplicate_compiler_generated_deps=$opt_preserve_dup_deps
-        ;;
-    esac
+    # Keeping compiler generated duplicates in $postdeps and $predeps is not
+    # harmful, and is necessary in a majority of systems that use it to satisfy
+    # symbol dependencies.
+    opt_duplicate_compiler_generated_deps=:
 
     $opt_help || {
       # Sanity checks first:
@@ -7272,12 +7265,10 @@ func_mode_link ()
       # -tp=*                Portland pgcc target processor selection
       # --sysroot=*          for sysroot support
       # -O*, -g*, -flto*, -fwhopr*, -fuse-linker-plugin GCC link-time optimization
-      # -specs=*             GCC specs files
       # -stdlib=*            select c++ std lib with clang
       -64|-mips[0-9]|-r[0-9][0-9]*|-xarch=*|-xtarget=*|+DA*|+DD*|-q*|-m*| \
       -t[45]*|-txscale*|-p|-pg|--coverage|-fprofile-*|-F*|@*|-tp=*|--sysroot=*| \
-      -O*|-g*|-flto*|-fwhopr*|-fuse-linker-plugin|-fstack-protector*|-stdlib=*| \
-      -specs=*)
+      -O*|-g*|-flto*|-fwhopr*|-fuse-linker-plugin|-fstack-protector*|-stdlib=*)
         func_quote_for_eval "$arg"
 	arg=$func_quote_for_eval_result
         func_append compile_command " $arg"

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -22,7 +22,6 @@ TESTS = $(test_exe) $(test_scripts) \
 	$(selector_tests:=.sw) \
 	$(selector_tests:=.nx) \
 	$(selector_tests:=.mix) \
-	$(selector_tests:=.mix2) \
 	test_zeroinput.nx
 
 check_PROGRAMS = $(test_exe) $(selector_tests) $(other_tests)
@@ -78,10 +77,6 @@ ABIDW_FLAGS = --no-corpus-path --drop-undefined-syms --drop-private-types \
 
 %.mix:
 	@$(srcdir)/gen_test.sh 3 $(*F) > $@
-	@chmod +x $@
-
-%.mix2:
-	@$(srcdir)/gen_test.sh 4 $(*F) > $@
 	@chmod +x $@
 
 regen-abi:

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -10,6 +10,9 @@ test_scripts = test_abi
 test_exe = test_adler32 \
 	   test_buf_error \
 	   test_crc32 \
+	   test_reset \
+	   test_resetKeep \
+	   test_reset2 \
 	   test_inflatesyncpoint \
 	   test_multithread_stress \
 	   test_pid_reuse
@@ -41,6 +44,15 @@ test_deflate_SOURCES = test_deflate.c \
 		       deflate/perf.c \
 		       deflate/random_buffer.c \
 		       deflate/z_finish.c
+
+test_reset_SOURCES = test_reset.c \
+		     test_utils.c
+
+test_resetKeep_SOURCES = $(test_reset_SOURCES)
+test_resetKeep_CPPFLAGS = -DKEEP
+
+test_reset2_SOURCES = $(test_reset_SOURCES)
+test_reset2_CPPFLAGS = -DINFRESET2
 
 test_inflate_SOURCES = test_inflate.c \
 		       test_utils.c \

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -90,7 +90,7 @@ host_triplet = @host@
 target_triplet = @target@
 TESTS = $(am__EXEEXT_1) $(test_scripts) $(am__EXEEXT_4) \
 	$(am__EXEEXT_5) $(am__EXEEXT_6) $(am__EXEEXT_7) \
-	$(am__EXEEXT_8) test_zeroinput.nx
+	test_zeroinput.nx
 check_PROGRAMS = $(am__EXEEXT_1) $(am__EXEEXT_2) $(am__EXEEXT_3)
 subdir = test
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
@@ -468,8 +468,6 @@ am__EXEEXT_6 = test_stress.nx test_deflate.nx test_inflate.nx \
 	test_dict.nx test_gz.nx
 am__EXEEXT_7 = test_stress.mix test_deflate.mix test_inflate.mix \
 	test_dict.mix test_gz.mix
-am__EXEEXT_8 = test_stress.mix2 test_deflate.mix2 test_inflate.mix2 \
-	test_dict.mix2 test_gz.mix2
 TEST_SUITE_LOG = test-suite.log
 TEST_EXTENSIONS = @EXEEXT@ .test
 LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver
@@ -1322,41 +1320,6 @@ test_gz.mix.log: test_gz.mix
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
-test_stress.mix2.log: test_stress.mix2
-	@p='test_stress.mix2'; \
-	b='test_stress.mix2'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-test_deflate.mix2.log: test_deflate.mix2
-	@p='test_deflate.mix2'; \
-	b='test_deflate.mix2'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-test_inflate.mix2.log: test_inflate.mix2
-	@p='test_inflate.mix2'; \
-	b='test_inflate.mix2'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-test_dict.mix2.log: test_dict.mix2
-	@p='test_dict.mix2'; \
-	b='test_dict.mix2'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-test_gz.mix2.log: test_gz.mix2
-	@p='test_gz.mix2'; \
-	b='test_gz.mix2'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
 test_zeroinput.nx.log: test_zeroinput.nx
 	@p='test_zeroinput.nx'; \
 	b='test_zeroinput.nx'; \
@@ -1625,10 +1588,6 @@ uninstall-am:
 
 %.mix:
 	@$(srcdir)/gen_test.sh 3 $(*F) > $@
-	@chmod +x $@
-
-%.mix2:
-	@$(srcdir)/gen_test.sh 4 $(*F) > $@
 	@chmod +x $@
 
 regen-abi:

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -108,7 +108,9 @@ CONFIG_HEADER = $(top_builddir)/config.h
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
 am__EXEEXT_1 = test_adler32$(EXEEXT) test_buf_error$(EXEEXT) \
-	test_crc32$(EXEEXT) test_inflatesyncpoint$(EXEEXT) \
+	test_crc32$(EXEEXT) test_reset$(EXEEXT) \
+	test_resetKeep$(EXEEXT) test_reset2$(EXEEXT) \
+	test_inflatesyncpoint$(EXEEXT) \
 	test_multithread_stress$(EXEEXT) test_pid_reuse$(EXEEXT)
 am__EXEEXT_2 = test_stress$(EXEEXT) test_deflate$(EXEEXT) \
 	test_inflate$(EXEEXT) test_dict$(EXEEXT) test_gz$(EXEEXT)
@@ -169,6 +171,22 @@ am_test_pid_reuse_OBJECTS = test_pid_reuse.$(OBJEXT)
 test_pid_reuse_OBJECTS = $(am_test_pid_reuse_OBJECTS)
 test_pid_reuse_LDADD = $(LDADD)
 test_pid_reuse_DEPENDENCIES = ../lib/libnxz.la $(am__DEPENDENCIES_1)
+am_test_reset_OBJECTS = test_reset.$(OBJEXT) test_utils.$(OBJEXT)
+test_reset_OBJECTS = $(am_test_reset_OBJECTS)
+test_reset_LDADD = $(LDADD)
+test_reset_DEPENDENCIES = ../lib/libnxz.la $(am__DEPENDENCIES_1)
+am__objects_1 = test_reset2-test_reset.$(OBJEXT) \
+	test_reset2-test_utils.$(OBJEXT)
+am_test_reset2_OBJECTS = $(am__objects_1)
+test_reset2_OBJECTS = $(am_test_reset2_OBJECTS)
+test_reset2_LDADD = $(LDADD)
+test_reset2_DEPENDENCIES = ../lib/libnxz.la $(am__DEPENDENCIES_1)
+am__objects_2 = test_resetKeep-test_reset.$(OBJEXT) \
+	test_resetKeep-test_utils.$(OBJEXT)
+am_test_resetKeep_OBJECTS = $(am__objects_2)
+test_resetKeep_OBJECTS = $(am_test_resetKeep_OBJECTS)
+test_resetKeep_LDADD = $(LDADD)
+test_resetKeep_DEPENDENCIES = ../lib/libnxz.la $(am__DEPENDENCIES_1)
 am_test_stress_OBJECTS = test_stress.$(OBJEXT) test_utils.$(OBJEXT)
 test_stress_OBJECTS = $(am_test_stress_OBJECTS)
 test_stress_LDADD = $(LDADD)
@@ -199,11 +217,15 @@ am__depfiles_remade = ./$(DEPDIR)/test_adler32.Po \
 	./$(DEPDIR)/test_gz.Po ./$(DEPDIR)/test_inflate.Po \
 	./$(DEPDIR)/test_inflatesyncpoint.Po \
 	./$(DEPDIR)/test_multithread_stress.Po \
-	./$(DEPDIR)/test_pid_reuse.Po ./$(DEPDIR)/test_stress.Po \
-	./$(DEPDIR)/test_utils.Po ./$(DEPDIR)/test_zeroinput.Po \
-	deflate/$(DEPDIR)/0.Po deflate/$(DEPDIR)/compress.Po \
-	deflate/$(DEPDIR)/hello.Po deflate/$(DEPDIR)/perf.Po \
-	deflate/$(DEPDIR)/random_buffer.Po \
+	./$(DEPDIR)/test_pid_reuse.Po ./$(DEPDIR)/test_reset.Po \
+	./$(DEPDIR)/test_reset2-test_reset.Po \
+	./$(DEPDIR)/test_reset2-test_utils.Po \
+	./$(DEPDIR)/test_resetKeep-test_reset.Po \
+	./$(DEPDIR)/test_resetKeep-test_utils.Po \
+	./$(DEPDIR)/test_stress.Po ./$(DEPDIR)/test_utils.Po \
+	./$(DEPDIR)/test_zeroinput.Po deflate/$(DEPDIR)/0.Po \
+	deflate/$(DEPDIR)/compress.Po deflate/$(DEPDIR)/hello.Po \
+	deflate/$(DEPDIR)/perf.Po deflate/$(DEPDIR)/random_buffer.Po \
 	deflate/$(DEPDIR)/z_finish.Po \
 	inflate/$(DEPDIR)/random_buffer.Po
 am__mv = mv -f
@@ -230,13 +252,17 @@ SOURCES = $(test_adler32_SOURCES) $(test_buf_error_SOURCES) \
 	$(test_dict_SOURCES) $(test_gz_SOURCES) \
 	$(test_inflate_SOURCES) $(test_inflatesyncpoint_SOURCES) \
 	$(test_multithread_stress_SOURCES) $(test_pid_reuse_SOURCES) \
-	$(test_stress_SOURCES) $(test_zeroinput_SOURCES)
+	$(test_reset_SOURCES) $(test_reset2_SOURCES) \
+	$(test_resetKeep_SOURCES) $(test_stress_SOURCES) \
+	$(test_zeroinput_SOURCES)
 DIST_SOURCES = $(test_adler32_SOURCES) $(test_buf_error_SOURCES) \
 	$(test_crc32_SOURCES) $(test_deflate_SOURCES) \
 	$(test_dict_SOURCES) $(test_gz_SOURCES) \
 	$(test_inflate_SOURCES) $(test_inflatesyncpoint_SOURCES) \
 	$(test_multithread_stress_SOURCES) $(test_pid_reuse_SOURCES) \
-	$(test_stress_SOURCES) $(test_zeroinput_SOURCES)
+	$(test_reset_SOURCES) $(test_reset2_SOURCES) \
+	$(test_resetKeep_SOURCES) $(test_stress_SOURCES) \
+	$(test_zeroinput_SOURCES)
 RECURSIVE_TARGETS = all-recursive check-recursive cscopelist-recursive \
 	ctags-recursive dvi-recursive html-recursive info-recursive \
 	install-data-recursive install-dvi-recursive \
@@ -676,6 +702,9 @@ test_scripts = test_abi
 test_exe = test_adler32 \
 	   test_buf_error \
 	   test_crc32 \
+	   test_reset \
+	   test_resetKeep \
+	   test_reset2 \
 	   test_inflatesyncpoint \
 	   test_multithread_stress \
 	   test_pid_reuse
@@ -695,6 +724,13 @@ test_deflate_SOURCES = test_deflate.c \
 		       deflate/random_buffer.c \
 		       deflate/z_finish.c
 
+test_reset_SOURCES = test_reset.c \
+		     test_utils.c
+
+test_resetKeep_SOURCES = $(test_reset_SOURCES)
+test_resetKeep_CPPFLAGS = -DKEEP
+test_reset2_SOURCES = $(test_reset_SOURCES)
+test_reset2_CPPFLAGS = -DINFRESET2
 test_inflate_SOURCES = test_inflate.c \
 		       test_utils.c \
 		       inflate/random_buffer.c
@@ -818,6 +854,18 @@ test_pid_reuse$(EXEEXT): $(test_pid_reuse_OBJECTS) $(test_pid_reuse_DEPENDENCIES
 	@rm -f test_pid_reuse$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_pid_reuse_OBJECTS) $(test_pid_reuse_LDADD) $(LIBS)
 
+test_reset$(EXEEXT): $(test_reset_OBJECTS) $(test_reset_DEPENDENCIES) $(EXTRA_test_reset_DEPENDENCIES) 
+	@rm -f test_reset$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(test_reset_OBJECTS) $(test_reset_LDADD) $(LIBS)
+
+test_reset2$(EXEEXT): $(test_reset2_OBJECTS) $(test_reset2_DEPENDENCIES) $(EXTRA_test_reset2_DEPENDENCIES) 
+	@rm -f test_reset2$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(test_reset2_OBJECTS) $(test_reset2_LDADD) $(LIBS)
+
+test_resetKeep$(EXEEXT): $(test_resetKeep_OBJECTS) $(test_resetKeep_DEPENDENCIES) $(EXTRA_test_resetKeep_DEPENDENCIES) 
+	@rm -f test_resetKeep$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(test_resetKeep_OBJECTS) $(test_resetKeep_LDADD) $(LIBS)
+
 test_stress$(EXEEXT): $(test_stress_OBJECTS) $(test_stress_DEPENDENCIES) $(EXTRA_test_stress_DEPENDENCIES) 
 	@rm -f test_stress$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_stress_OBJECTS) $(test_stress_LDADD) $(LIBS)
@@ -844,6 +892,11 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_inflatesyncpoint.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_multithread_stress.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_pid_reuse.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_reset.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_reset2-test_reset.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_reset2-test_utils.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_resetKeep-test_reset.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_resetKeep-test_utils.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_stress.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_utils.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_zeroinput.Po@am__quote@ # am--include-marker
@@ -884,6 +937,62 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='$<' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LTCOMPILE) -c -o $@ $<
+
+test_reset2-test_reset.o: test_reset.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_reset2_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT test_reset2-test_reset.o -MD -MP -MF $(DEPDIR)/test_reset2-test_reset.Tpo -c -o test_reset2-test_reset.o `test -f 'test_reset.c' || echo '$(srcdir)/'`test_reset.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/test_reset2-test_reset.Tpo $(DEPDIR)/test_reset2-test_reset.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_reset.c' object='test_reset2-test_reset.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_reset2_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o test_reset2-test_reset.o `test -f 'test_reset.c' || echo '$(srcdir)/'`test_reset.c
+
+test_reset2-test_reset.obj: test_reset.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_reset2_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT test_reset2-test_reset.obj -MD -MP -MF $(DEPDIR)/test_reset2-test_reset.Tpo -c -o test_reset2-test_reset.obj `if test -f 'test_reset.c'; then $(CYGPATH_W) 'test_reset.c'; else $(CYGPATH_W) '$(srcdir)/test_reset.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/test_reset2-test_reset.Tpo $(DEPDIR)/test_reset2-test_reset.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_reset.c' object='test_reset2-test_reset.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_reset2_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o test_reset2-test_reset.obj `if test -f 'test_reset.c'; then $(CYGPATH_W) 'test_reset.c'; else $(CYGPATH_W) '$(srcdir)/test_reset.c'; fi`
+
+test_reset2-test_utils.o: test_utils.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_reset2_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT test_reset2-test_utils.o -MD -MP -MF $(DEPDIR)/test_reset2-test_utils.Tpo -c -o test_reset2-test_utils.o `test -f 'test_utils.c' || echo '$(srcdir)/'`test_utils.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/test_reset2-test_utils.Tpo $(DEPDIR)/test_reset2-test_utils.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_utils.c' object='test_reset2-test_utils.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_reset2_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o test_reset2-test_utils.o `test -f 'test_utils.c' || echo '$(srcdir)/'`test_utils.c
+
+test_reset2-test_utils.obj: test_utils.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_reset2_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT test_reset2-test_utils.obj -MD -MP -MF $(DEPDIR)/test_reset2-test_utils.Tpo -c -o test_reset2-test_utils.obj `if test -f 'test_utils.c'; then $(CYGPATH_W) 'test_utils.c'; else $(CYGPATH_W) '$(srcdir)/test_utils.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/test_reset2-test_utils.Tpo $(DEPDIR)/test_reset2-test_utils.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_utils.c' object='test_reset2-test_utils.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_reset2_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o test_reset2-test_utils.obj `if test -f 'test_utils.c'; then $(CYGPATH_W) 'test_utils.c'; else $(CYGPATH_W) '$(srcdir)/test_utils.c'; fi`
+
+test_resetKeep-test_reset.o: test_reset.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_resetKeep_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT test_resetKeep-test_reset.o -MD -MP -MF $(DEPDIR)/test_resetKeep-test_reset.Tpo -c -o test_resetKeep-test_reset.o `test -f 'test_reset.c' || echo '$(srcdir)/'`test_reset.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/test_resetKeep-test_reset.Tpo $(DEPDIR)/test_resetKeep-test_reset.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_reset.c' object='test_resetKeep-test_reset.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_resetKeep_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o test_resetKeep-test_reset.o `test -f 'test_reset.c' || echo '$(srcdir)/'`test_reset.c
+
+test_resetKeep-test_reset.obj: test_reset.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_resetKeep_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT test_resetKeep-test_reset.obj -MD -MP -MF $(DEPDIR)/test_resetKeep-test_reset.Tpo -c -o test_resetKeep-test_reset.obj `if test -f 'test_reset.c'; then $(CYGPATH_W) 'test_reset.c'; else $(CYGPATH_W) '$(srcdir)/test_reset.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/test_resetKeep-test_reset.Tpo $(DEPDIR)/test_resetKeep-test_reset.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_reset.c' object='test_resetKeep-test_reset.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_resetKeep_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o test_resetKeep-test_reset.obj `if test -f 'test_reset.c'; then $(CYGPATH_W) 'test_reset.c'; else $(CYGPATH_W) '$(srcdir)/test_reset.c'; fi`
+
+test_resetKeep-test_utils.o: test_utils.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_resetKeep_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT test_resetKeep-test_utils.o -MD -MP -MF $(DEPDIR)/test_resetKeep-test_utils.Tpo -c -o test_resetKeep-test_utils.o `test -f 'test_utils.c' || echo '$(srcdir)/'`test_utils.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/test_resetKeep-test_utils.Tpo $(DEPDIR)/test_resetKeep-test_utils.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_utils.c' object='test_resetKeep-test_utils.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_resetKeep_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o test_resetKeep-test_utils.o `test -f 'test_utils.c' || echo '$(srcdir)/'`test_utils.c
+
+test_resetKeep-test_utils.obj: test_utils.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_resetKeep_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT test_resetKeep-test_utils.obj -MD -MP -MF $(DEPDIR)/test_resetKeep-test_utils.Tpo -c -o test_resetKeep-test_utils.obj `if test -f 'test_utils.c'; then $(CYGPATH_W) 'test_utils.c'; else $(CYGPATH_W) '$(srcdir)/test_utils.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/test_resetKeep-test_utils.Tpo $(DEPDIR)/test_resetKeep-test_utils.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_utils.c' object='test_resetKeep-test_utils.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_resetKeep_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o test_resetKeep-test_utils.obj `if test -f 'test_utils.c'; then $(CYGPATH_W) 'test_utils.c'; else $(CYGPATH_W) '$(srcdir)/test_utils.c'; fi`
 
 mostlyclean-libtool:
 	-rm -f *.lo
@@ -1148,6 +1257,27 @@ test_buf_error.log: test_buf_error$(EXEEXT)
 test_crc32.log: test_crc32$(EXEEXT)
 	@p='test_crc32$(EXEEXT)'; \
 	b='test_crc32'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test_reset.log: test_reset$(EXEEXT)
+	@p='test_reset$(EXEEXT)'; \
+	b='test_reset'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test_resetKeep.log: test_resetKeep$(EXEEXT)
+	@p='test_resetKeep$(EXEEXT)'; \
+	b='test_resetKeep'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test_reset2.log: test_reset2$(EXEEXT)
+	@p='test_reset2$(EXEEXT)'; \
+	b='test_reset2'; \
 	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
@@ -1460,6 +1590,11 @@ distclean: distclean-recursive
 	-rm -f ./$(DEPDIR)/test_inflatesyncpoint.Po
 	-rm -f ./$(DEPDIR)/test_multithread_stress.Po
 	-rm -f ./$(DEPDIR)/test_pid_reuse.Po
+	-rm -f ./$(DEPDIR)/test_reset.Po
+	-rm -f ./$(DEPDIR)/test_reset2-test_reset.Po
+	-rm -f ./$(DEPDIR)/test_reset2-test_utils.Po
+	-rm -f ./$(DEPDIR)/test_resetKeep-test_reset.Po
+	-rm -f ./$(DEPDIR)/test_resetKeep-test_utils.Po
 	-rm -f ./$(DEPDIR)/test_stress.Po
 	-rm -f ./$(DEPDIR)/test_utils.Po
 	-rm -f ./$(DEPDIR)/test_zeroinput.Po
@@ -1525,6 +1660,11 @@ maintainer-clean: maintainer-clean-recursive
 	-rm -f ./$(DEPDIR)/test_inflatesyncpoint.Po
 	-rm -f ./$(DEPDIR)/test_multithread_stress.Po
 	-rm -f ./$(DEPDIR)/test_pid_reuse.Po
+	-rm -f ./$(DEPDIR)/test_reset.Po
+	-rm -f ./$(DEPDIR)/test_reset2-test_reset.Po
+	-rm -f ./$(DEPDIR)/test_reset2-test_utils.Po
+	-rm -f ./$(DEPDIR)/test_resetKeep-test_reset.Po
+	-rm -f ./$(DEPDIR)/test_resetKeep-test_utils.Po
 	-rm -f ./$(DEPDIR)/test_stress.Po
 	-rm -f ./$(DEPDIR)/test_utils.Po
 	-rm -f ./$(DEPDIR)/test_zeroinput.Po

--- a/test/test_reset.c
+++ b/test/test_reset.c
@@ -1,0 +1,136 @@
+/* Test if deflateReset[Keep] work as expected */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <string.h>
+#include <unistd.h>
+#include <zlib.h>
+#include <time.h>
+
+#include "nx_zlib.h"
+#include "test.h"
+#include "test_utils.h"
+
+#ifdef KEEP
+# define CALL_DEFLATE_RESET(strm) deflateResetKeep(strm)
+# define CALL_INFLATE_RESET(strm) inflateResetKeep(strm)
+#elif defined(INFRESET2)
+# define CALL_DEFLATE_RESET(strm) deflateReset(strm)
+# define CALL_INFLATE_RESET(strm) inflateReset2(strm, DEF_WBITS)
+#else
+# define CALL_DEFLATE_RESET(strm) deflateReset(strm)
+# define CALL_INFLATE_RESET(strm) inflateReset(strm)
+#endif
+
+static void validate_stream(z_stream *strm, struct internal_state *sw_state,
+			    nx_streamp hw_state) {
+#ifdef KEEP
+	if (hw_state->sw_stream) {
+		/* Pointers to internal structures shouldn't change */
+		assert(hw_state->sw_stream == sw_state);
+	}
+#else
+	/* NX state should always be loaded */
+	assert(has_nx_state(strm));
+
+	/* Pointers to internal structures shouldn't change */
+	nx_streamp s = (nx_streamp) strm->state;
+	assert(s == hw_state);
+	assert(s->sw_stream == sw_state);
+
+	/* Should be ready for fallback */
+	assert(s->switchable == 1);
+#endif
+}
+
+int main()
+{
+	Byte *src, *compr, *uncompr;
+	unsigned int src_len = DATA_MAX_LEN;
+	unsigned int compr_len = src_len*2;
+	unsigned int uncompr_len = src_len;
+	z_stream strm;
+
+	generate_random_data(src_len);
+	src = (Byte*)&ran_data[0];
+
+	compr = (Byte*)calloc((uInt)compr_len, 1);
+	uncompr = (Byte*)calloc((uInt)uncompr_len, 1);
+	if (compr == NULL || uncompr == NULL) {
+		printf("*** alloc buffer failed\n");
+		return TEST_ERROR;
+	}
+
+	/* Ensure there is no garbage in the structure, which could cause
+	   segmentation fault.  */
+	memset(&strm, 0, sizeof(z_stream));
+
+	/* Reseting an uninitialized stream must fail */
+	zcheck(CALL_DEFLATE_RESET(&strm), Z_STREAM_ERROR);
+	zcheck(CALL_INFLATE_RESET(&strm), Z_STREAM_ERROR);
+
+	#define SW 0
+	#define NX 1
+	int rounds[] = {SW,NX,NX,SW,SW};
+	const size_t nrounds = sizeof(rounds)/(sizeof(int));
+	unsigned long total_out;
+
+	for (size_t i = 0 ; i < nrounds ; i++) {
+		zcheck(deflateInit(&strm, Z_DEFAULT_COMPRESSION), Z_OK);
+		if (!has_nx_state(&strm)) {
+			fprintf(stderr, "Couldn't allocate window. Is the system"
+				"out of credits? Skipping.");
+			return TEST_SKIP;
+		}
+
+		nx_streamp hw_state = (nx_streamp) strm.state;
+		struct internal_state *sw_state = hw_state->sw_stream;
+
+		/* Reseting between init and deflate should be OK */
+		zcheck(CALL_DEFLATE_RESET(&strm), Z_OK);
+
+		strm.next_in   = src;
+		strm.next_out  = compr;
+		strm.avail_in  = rounds[i] == SW ? 100 : src_len;
+		strm.avail_out = compr_len;
+
+		zcheck(deflate(&strm, Z_FINISH), Z_STREAM_END);
+		total_out = strm.total_out;
+		zcheck(CALL_DEFLATE_RESET(&strm), Z_OK);
+		validate_stream(&strm, sw_state, hw_state);
+		zcheck(deflateEnd(&strm), Z_OK);
+
+		memset(&strm, 0, sizeof(strm));
+
+		zcheck(inflateInit(&strm), Z_OK);
+		if (!has_nx_state(&strm)) {
+			fprintf(stderr, "Couldn't allocate window. Is the system"
+				"out of credits? Skipping.");
+			return TEST_SKIP;
+		}
+
+		hw_state = (nx_streamp) strm.state;
+		sw_state = hw_state->sw_stream;
+
+		/* Reseting between init and inflate should be OK */
+		zcheck(CALL_INFLATE_RESET(&strm), Z_OK);
+
+		strm.next_in   = compr;
+		strm.next_out  = uncompr;
+		strm.avail_in  = (unsigned int) total_out;
+		strm.avail_out = uncompr_len;
+
+		zcheck(inflate(&strm, Z_FINISH), Z_STREAM_END);
+		zcheck(CALL_INFLATE_RESET(&strm), Z_OK);
+		validate_stream(&strm, sw_state, hw_state);
+		zcheck(inflateEnd(&strm), Z_OK);
+
+		memset(&strm, 0, sizeof(strm));
+	}
+
+	printf("*** %s passed\n", __FILE__);
+	free(compr);
+	free(uncompr);
+	return TEST_OK;
+}


### PR DESCRIPTION
Please read commit messages for more details.

This is marked as draft because I haven't found a solution for #187 yet. This PR is affected by that issue in two situations:
1. libnxz calls `sw_deflateInit2_`, then zlib calls `deflateReset`, which ends up calling libnxz's `deflateReset`.
2. On `deflateReset` libnxz calls `sw_deflateReset`, which calls `deflateResetKeep`, which ends up using libnxz's `deflateResetKeep`.

The first one is easier to workaround because there won't be an entry in `stream_map`, so we now we have to call zlib's `deflateReset`. I couldn't find a way to detect calls from zlib for case 2 yet.