### PR TITLE
Print error number in compdecomp and compdecomp_th

### DIFF
--- a/samples/compdecomp.c
+++ b/samples/compdecomp.c
@@ -120,6 +120,7 @@ int compress_file(int argc, char **argv)
 	int i;
 	struct timeval ts, te;
 	double elapsed;
+	int ret;
 
 	if (argc != 2) {
 		fprintf(stderr, "usage: %s <fname>\n", argv[0]);
@@ -143,9 +144,10 @@ int compress_file(int argc, char **argv)
 	compdata_len = compbuf_len;
 	/* compdata_len is the buffer length before the call; returned
 	   as actual compressed data len on return */
-	if (Z_OK != compress((Bytef *)compbuf, &compdata_len, (Bytef *)inbuf,
-	    (uLong)inlen)) {
-		fprintf(stderr, "compress error\n");
+	ret = compress((Bytef *)compbuf, &compdata_len, (Bytef *)inbuf,
+		       (uLong)inlen);
+	if (ret != Z_OK) {
+		fprintf(stderr, "compress error %d\n", ret);
 		return -1;
 	}
 	fprintf(stderr, "compressed %ld to %ld bytes\n", (long)inlen,
@@ -155,9 +157,10 @@ int compress_file(int argc, char **argv)
 	decompdata_len = decompbuf_len;
 	/* decompdata_len is the buffer length before the call;
 	   returned as actual uncompressed data len on return */
-	if (Z_OK != uncompress((Bytef *)decompbuf, &decompdata_len,
-	    (Bytef *)compbuf, (uLong)compdata_len)) {
-		fprintf(stderr, "uncompress error\n");
+	ret = uncompress((Bytef *)decompbuf, &decompdata_len,
+			 (Bytef *)compbuf, (uLong)compdata_len);
+	if (ret != Z_OK) {
+		fprintf(stderr, "uncompress error %d\n", ret);
 		return -1;
 	}
 	fprintf(stderr, "uncompressed %ld to %ld bytes\n", (long)compdata_len,
@@ -176,9 +179,10 @@ int compress_file(int argc, char **argv)
 
 	for (i = 0; i < iterations; i++) {
 		compdata_len = compbuf_len;
-		if (Z_OK != compress((Bytef *)compbuf, &compdata_len,
-		    (Bytef *)inbuf, (uLong)inlen)) {
-			fprintf(stderr, "compress error\n");
+		ret = compress((Bytef *)compbuf, &compdata_len,
+			       (Bytef *)inbuf, (uLong)inlen);
+		if (ret != Z_OK) {
+			fprintf(stderr, "compress error %d\n", ret);
 			return -1;
 		}
 	}
@@ -201,9 +205,10 @@ int compress_file(int argc, char **argv)
 		decompdata_len = decompbuf_len;
 		/* decompdata_len is the buffer length before the call;
 		   returned as actual uncompressed data len on return */
-		if (Z_OK != uncompress((Bytef *)decompbuf, &decompdata_len,
-		    (Bytef *)compbuf, (uLong)compdata_len)) {
-			fprintf(stderr, "uncompress error\n");
+		ret = uncompress((Bytef *)decompbuf, &decompdata_len,
+				(Bytef *)compbuf, (uLong)compdata_len);
+		if (ret != Z_OK) {
+			fprintf(stderr, "uncompress error %d\n", ret);
 			return -1;
 		}
 	}

--- a/samples/compdecomp_th.c
+++ b/samples/compdecomp_th.c
@@ -145,6 +145,7 @@ void *comp_file_multith(void *argsv)
 	double elapsed;
 	thread_args_t *argsp = (thread_args_t *) argsv;
 	int tid;
+	int ret;
 
 	inbuf = argsp->inbuf;
 	inlen = argsp->inlen;
@@ -162,9 +163,10 @@ void *comp_file_multith(void *argsv)
 	compdata_len = compbuf_len;
 	/* compdata_len is the buffer length before the call; returned
 	   as actual compressed data len on return */
-	if (Z_OK != compress((Bytef *)compbuf, &compdata_len, (Bytef *)inbuf,
-	    (uLong)inlen)) {
-		fprintf(stderr, "tid %d: compress error\n", tid);
+	ret = compress((Bytef *)compbuf, &compdata_len, (Bytef *)inbuf,
+		       (uLong)inlen);
+	if (ret != Z_OK) {
+		fprintf(stderr, "tid %d: compress error %d\n", tid, ret);
 		return (void *) -1;
 	}
 
@@ -175,9 +177,10 @@ void *comp_file_multith(void *argsv)
 	decompdata_len = decompbuf_len;
 	/* decompdata_len is the buffer length before the call;
 	   returned as actual uncompressed data len on return */
-	if (Z_OK != uncompress((Bytef *)decompbuf, &decompdata_len,
-	    (Bytef *)compbuf, (uLong)compdata_len)) {
-		fprintf(stderr, "tid %d: uncompress error\n", tid);
+	ret = uncompress((Bytef *)decompbuf, &decompdata_len,
+			 (Bytef *)compbuf, (uLong)compdata_len);
+	if (ret != Z_OK) {
+		fprintf(stderr, "tid %d: uncompress error %d\n", tid, ret);
 		return (void *) -1;
 	}
 
@@ -193,9 +196,11 @@ void *comp_file_multith(void *argsv)
 
 	for (i = 0; i < iterations; i++) {
 		compdata_len = compbuf_len;
-		if (Z_OK != compress((Bytef *)compbuf, &compdata_len,
-		    (Bytef *)inbuf, (uLong)inlen)) {
-			fprintf(stderr, "tid %d: compress error\n", tid);
+		ret = compress((Bytef *)compbuf, &compdata_len,
+			       (Bytef *)inbuf, (uLong)inlen);
+		if (ret != Z_OK) {
+			fprintf(stderr, "tid %d: compress error %d\n", tid,
+				ret);
 			return (void *) -1;
 		}
 	}
@@ -236,6 +241,7 @@ void *decomp_file_multith(void *argsv)
 #ifdef SIMPLE_CHECKSUM
 	unsigned long cksum = 1;
 #endif
+	int ret;
 
 	inbuf = argsp->inbuf;
 	inlen = argsp->inlen;
@@ -253,9 +259,10 @@ void *decomp_file_multith(void *argsv)
 	compdata_len = compbuf_len;
 	/* compdata_len is the buffer length before the call; returned
 	   as actual compressed data len on return */
-	if (Z_OK != compress((Bytef *)compbuf, &compdata_len, (Bytef *)inbuf,
-	    (uLong)inlen)) {
-		fprintf(stderr, "tid %d: compress error\n", tid);
+	ret = compress((Bytef *)compbuf, &compdata_len, (Bytef *)inbuf,
+		       (uLong)inlen);
+	if (ret != Z_OK) {
+		fprintf(stderr, "tid %d: compress error %d\n", tid, ret);
 		return (void *) -1;
 	}
 
@@ -267,9 +274,10 @@ void *decomp_file_multith(void *argsv)
 	decompdata_len = decompbuf_len;
 	/* decompdata_len is the buffer length before the call;
 	   returned as actual uncompressed data len on return */
-	if (Z_OK != uncompress((Bytef *)decompbuf, &decompdata_len,
-	    (Bytef *)compbuf, (uLong)compdata_len)) {
-		fprintf(stderr, "uncompress error\n");
+	ret = uncompress((Bytef *)decompbuf, &decompdata_len,
+			 (Bytef *)compbuf, (uLong)compdata_len);
+	if (ret != Z_OK) {
+		fprintf(stderr, "uncompress error %d\n", ret);
 		return (void *) -1;
 	}
 
@@ -287,9 +295,11 @@ void *decomp_file_multith(void *argsv)
 		decompdata_len = decompbuf_len;
 		/* decompdata_len is the buffer length before the call;
 		   returned as actual uncompressed data len on return */
-		if (Z_OK != uncompress((Bytef *)decompbuf, &decompdata_len,
-		    (Bytef *)compbuf, (uLong)compdata_len)) {
-			fprintf(stderr, "tid %d: uncompress error\n", tid);
+		ret = uncompress((Bytef *)decompbuf, &decompdata_len,
+				 (Bytef *)compbuf, (uLong)compdata_len);
+		if (ret != Z_OK) {
+			fprintf(stderr, "tid %d: uncompress error %d\n", tid,
+				ret);
 			return (void *) -1;
 		}
 


### PR DESCRIPTION
When detecting a failure in compress() or uncompress() print the error
number before failing.

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>