### PR TITLE
Miscelaneous fixes

### DIFF
--- a/lib/gzip_vas.c
+++ b/lib/gzip_vas.c
@@ -283,7 +283,7 @@ int nxu_run_job(nx_gzip_crb_cpb_t *cmdp, nx_devp_t nxhandle)
 	int ret=0, retries=0, wait_count=0;
 	uint64_t ticks_total = 0, wait_ticks = 0;
 	uint64_t freq = nx_get_freq();
-	int used_credits, total_credits, window_generation=-1;
+	int used_credits=0, total_credits=0, window_generation=-1;
 
 	assert(nxhandle != NULL);
 

--- a/lib/nx_zlib.c
+++ b/lib/nx_zlib.c
@@ -706,8 +706,8 @@ int nx_read_sysfs_entry(const char *path, int *val)
 				rc = 0;
 			}
 		}
+		close(fd);
 	}
-	(void) close(fd);
 
 	return rc;
 }

--- a/test/test_multithread_stress.c
+++ b/test/test_multithread_stress.c
@@ -229,6 +229,7 @@ int main(int argc, char **argv)
 	printf("Test Iterations:\t%d\n",test_iterations);
 
 	thread_info = (struct stats *) malloc(thread_num*sizeof(struct stats));
+	memset(thread_info, 0, thread_num * sizeof(struct stats));
 
 	if (generate_data_buffer(data_buf) != 0 || thread_info == NULL) {
 		free_data_buffer(data_buf);

--- a/test/test_multithread_stress.c
+++ b/test/test_multithread_stress.c
@@ -204,6 +204,7 @@ int main(int argc, char **argv)
 	unsigned long tsize = 0;
 	struct stats *thread_info;
 	int i;
+	int abort = 0;
 
 	if(argc == 4) {
 		thread_num = atoi(argv[1]);
@@ -245,7 +246,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	while(1){
+	while(abort == 0) {
 		sleep(1);
 		/*Check for finish*/
 		for (i = 0; i < thread_num; i++){
@@ -260,6 +261,7 @@ int main(int argc, char **argv)
 		}
 
 		if(finish_thread >= thread_num) break;
+		__atomic_load(&failed_thread, &abort, __ATOMIC_RELAXED);
 	}
 
 	for (int i = 0; i < thread_num; i++) {


### PR DESCRIPTION
- Properly initialize variables.
- Abort `test_multithread_stress` if a thread returns failure.
- Cosmetic improvements.
- Kill all the threads from `test_multithread_stress` after waiting for too long.
- Avoid closing an invalid file descriptor.