### PR TITLE
Fixes for GCC 14 and zlib-ng compat usage

### DIFF
--- a/lib/nx_crc.c
+++ b/lib/nx_crc.c
@@ -45,8 +45,6 @@
 typedef size_t   z_size_t;
 
 #undef NOBYFOUR
-#define ZEXPORT
-#define ZEXTERN extern
 #define ZSWAP32(q) bswap_32(q)
 
 

--- a/lib/nx_gzlib.c
+++ b/lib/nx_gzlib.c
@@ -142,7 +142,7 @@ gzFile __gzopen(const char* path, int fd, const char *mode, int force_nx)
 
 	state = malloc(sizeof(struct gz_state));
 	if (state == NULL)
-		return NULL;
+		return Z_NULL;
 	memset(state, 0, sizeof(struct gz_state));
 
 	if (path == NULL){
@@ -192,7 +192,7 @@ gzFile __gzopen(const char* path, int fd, const char *mode, int force_nx)
 		if (err == Z_OK) {
 			state->buf = malloc(BUF_LEN);
 			if (state->buf == NULL) {
-				err=Z_NULL;
+				err=Z_MEM_ERROR;
 			}
 		}
 	}
@@ -200,7 +200,7 @@ gzFile __gzopen(const char* path, int fd, const char *mode, int force_nx)
 		free(state);
 		if (err == Z_STREAM_ERROR)
 			errno = EINVAL;
-		return NULL;
+		return Z_NULL;
 	}
 
 	file = (gzFile) state;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -31,10 +31,12 @@ check_PROGRAMS = $(test_exe) $(selector_tests) $(other_tests)
 check_SCRIPTS = $(test_scripts)
 
 test_adler32_SOURCES = test_adler32.c
+test_adler32_CFLAGS  = -DSTDC
 
 test_buf_error_SOURCES = test_buf_error.c test_utils.c
 
 test_crc32_SOURCES = test_crc32.c
+test_crc32_CFLAGS  = -DSTDC
 
 test_deflate_SOURCES = test_deflate.c \
 		       test_utils.c \

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -115,7 +115,7 @@ am__EXEEXT_1 = test_adler32$(EXEEXT) test_buf_error$(EXEEXT) \
 am__EXEEXT_2 = test_stress$(EXEEXT) test_deflate$(EXEEXT) \
 	test_inflate$(EXEEXT) test_dict$(EXEEXT) test_gz$(EXEEXT)
 am__EXEEXT_3 = test_zeroinput$(EXEEXT)
-am_test_adler32_OBJECTS = test_adler32.$(OBJEXT)
+am_test_adler32_OBJECTS = test_adler32-test_adler32.$(OBJEXT)
 test_adler32_OBJECTS = $(am_test_adler32_OBJECTS)
 test_adler32_LDADD = $(LDADD)
 am__DEPENDENCIES_1 =
@@ -124,15 +124,21 @@ AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
+test_adler32_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(test_adler32_CFLAGS) \
+	$(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
 am_test_buf_error_OBJECTS = test_buf_error.$(OBJEXT) \
 	test_utils.$(OBJEXT)
 test_buf_error_OBJECTS = $(am_test_buf_error_OBJECTS)
 test_buf_error_LDADD = $(LDADD)
 test_buf_error_DEPENDENCIES = ../lib/libnxz.la $(am__DEPENDENCIES_1)
-am_test_crc32_OBJECTS = test_crc32.$(OBJEXT)
+am_test_crc32_OBJECTS = test_crc32-test_crc32.$(OBJEXT)
 test_crc32_OBJECTS = $(am_test_crc32_OBJECTS)
 test_crc32_LDADD = $(LDADD)
 test_crc32_DEPENDENCIES = ../lib/libnxz.la $(am__DEPENDENCIES_1)
+test_crc32_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(test_crc32_CFLAGS) \
+	$(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
 am__dirstamp = $(am__leading_dot)dirstamp
 am_test_deflate_OBJECTS = test_deflate.$(OBJEXT) test_utils.$(OBJEXT) \
 	deflate/0.$(OBJEXT) deflate/compress.$(OBJEXT) \
@@ -211,8 +217,9 @@ am__v_at_1 =
 DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)
 depcomp = $(SHELL) $(top_srcdir)/depcomp
 am__maybe_remake_depfiles = depfiles
-am__depfiles_remade = ./$(DEPDIR)/test_adler32.Po \
-	./$(DEPDIR)/test_buf_error.Po ./$(DEPDIR)/test_crc32.Po \
+am__depfiles_remade = ./$(DEPDIR)/test_adler32-test_adler32.Po \
+	./$(DEPDIR)/test_buf_error.Po \
+	./$(DEPDIR)/test_crc32-test_crc32.Po \
 	./$(DEPDIR)/test_deflate.Po ./$(DEPDIR)/test_dict.Po \
 	./$(DEPDIR)/test_gz.Po ./$(DEPDIR)/test_inflate.Po \
 	./$(DEPDIR)/test_inflatesyncpoint.Po \
@@ -301,8 +308,6 @@ am__define_uniq_tagged_files = \
   unique=`for i in $$list; do \
     if test -f "$$i"; then echo $$i; else echo $(srcdir)/$$i; fi; \
   done | $(am__uniquify_input)`
-ETAGS = etags
-CTAGS = ctags
 am__tty_colors_dummy = \
   mgn= red= grn= lgn= blu= brg= std=; \
   am__color_tests=no
@@ -485,6 +490,7 @@ am__set_TESTS_bases = \
   bases='$(TEST_LOGS)'; \
   bases=`for i in $$bases; do echo $$i; done | sed 's/\.log$$//'`; \
   bases=`echo $$bases`
+AM_TESTSUITE_SUMMARY_HEADER = ' for $(PACKAGE_STRING)'
 RECHECK_LOGS = $(TEST_LOGS)
 am__EXEEXT_4 = test_stress.auto test_deflate.auto test_inflate.auto \
 	test_dict.auto test_gz.auto
@@ -516,7 +522,7 @@ TEST_LOG_COMPILE = $(TEST_LOG_COMPILER) $(AM_TEST_LOG_FLAGS) \
 	$(TEST_LOG_FLAGS)
 DIST_SUBDIRS = $(SUBDIRS)
 am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/depcomp \
-	$(top_srcdir)/test-driver
+	$(top_srcdir)/test-driver README.md
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 am__relativize = \
   dir0=`pwd`; \
@@ -560,6 +566,8 @@ CCDEPMODE = @CCDEPMODE@
 CFLAGS = @CFLAGS@
 CPP = @CPP@
 CPPFLAGS = @CPPFLAGS@
+CSCOPE = @CSCOPE@
+CTAGS = @CTAGS@
 CYGPATH_W = @CYGPATH_W@
 DEFS = @DEFS@
 DEPDIR = @DEPDIR@
@@ -584,8 +592,10 @@ ECHO_C = @ECHO_C@
 ECHO_N = @ECHO_N@
 ECHO_T = @ECHO_T@
 EGREP = @EGREP@
+ETAGS = @ETAGS@
 EXEEXT = @EXEEXT@
 FGREP = @FGREP@
+FILECMD = @FILECMD@
 GREP = @GREP@
 GZIP = @GZIP@
 INSTALL = @INSTALL@
@@ -713,8 +723,10 @@ selector_tests = test_stress test_deflate test_inflate test_dict test_gz
 other_tests = test_zeroinput
 check_SCRIPTS = $(test_scripts)
 test_adler32_SOURCES = test_adler32.c
+test_adler32_CFLAGS = -DSTDC
 test_buf_error_SOURCES = test_buf_error.c test_utils.c
 test_crc32_SOURCES = test_crc32.c
+test_crc32_CFLAGS = -DSTDC
 test_deflate_SOURCES = test_deflate.c \
 		       test_utils.c \
 		       deflate/0.c \
@@ -790,7 +802,7 @@ clean-checkPROGRAMS:
 
 test_adler32$(EXEEXT): $(test_adler32_OBJECTS) $(test_adler32_DEPENDENCIES) $(EXTRA_test_adler32_DEPENDENCIES) 
 	@rm -f test_adler32$(EXEEXT)
-	$(AM_V_CCLD)$(LINK) $(test_adler32_OBJECTS) $(test_adler32_LDADD) $(LIBS)
+	$(AM_V_CCLD)$(test_adler32_LINK) $(test_adler32_OBJECTS) $(test_adler32_LDADD) $(LIBS)
 
 test_buf_error$(EXEEXT): $(test_buf_error_OBJECTS) $(test_buf_error_DEPENDENCIES) $(EXTRA_test_buf_error_DEPENDENCIES) 
 	@rm -f test_buf_error$(EXEEXT)
@@ -798,7 +810,7 @@ test_buf_error$(EXEEXT): $(test_buf_error_OBJECTS) $(test_buf_error_DEPENDENCIES
 
 test_crc32$(EXEEXT): $(test_crc32_OBJECTS) $(test_crc32_DEPENDENCIES) $(EXTRA_test_crc32_DEPENDENCIES) 
 	@rm -f test_crc32$(EXEEXT)
-	$(AM_V_CCLD)$(LINK) $(test_crc32_OBJECTS) $(test_crc32_LDADD) $(LIBS)
+	$(AM_V_CCLD)$(test_crc32_LINK) $(test_crc32_OBJECTS) $(test_crc32_LDADD) $(LIBS)
 deflate/$(am__dirstamp):
 	@$(MKDIR_P) deflate
 	@: > deflate/$(am__dirstamp)
@@ -882,9 +894,9 @@ mostlyclean-compile:
 distclean-compile:
 	-rm -f *.tab.c
 
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_adler32.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_adler32-test_adler32.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_buf_error.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_crc32.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_crc32-test_crc32.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_deflate.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_dict.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_gz.Po@am__quote@ # am--include-marker
@@ -937,6 +949,34 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='$<' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LTCOMPILE) -c -o $@ $<
+
+test_adler32-test_adler32.o: test_adler32.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(test_adler32_CFLAGS) $(CFLAGS) -MT test_adler32-test_adler32.o -MD -MP -MF $(DEPDIR)/test_adler32-test_adler32.Tpo -c -o test_adler32-test_adler32.o `test -f 'test_adler32.c' || echo '$(srcdir)/'`test_adler32.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/test_adler32-test_adler32.Tpo $(DEPDIR)/test_adler32-test_adler32.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_adler32.c' object='test_adler32-test_adler32.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(test_adler32_CFLAGS) $(CFLAGS) -c -o test_adler32-test_adler32.o `test -f 'test_adler32.c' || echo '$(srcdir)/'`test_adler32.c
+
+test_adler32-test_adler32.obj: test_adler32.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(test_adler32_CFLAGS) $(CFLAGS) -MT test_adler32-test_adler32.obj -MD -MP -MF $(DEPDIR)/test_adler32-test_adler32.Tpo -c -o test_adler32-test_adler32.obj `if test -f 'test_adler32.c'; then $(CYGPATH_W) 'test_adler32.c'; else $(CYGPATH_W) '$(srcdir)/test_adler32.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/test_adler32-test_adler32.Tpo $(DEPDIR)/test_adler32-test_adler32.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_adler32.c' object='test_adler32-test_adler32.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(test_adler32_CFLAGS) $(CFLAGS) -c -o test_adler32-test_adler32.obj `if test -f 'test_adler32.c'; then $(CYGPATH_W) 'test_adler32.c'; else $(CYGPATH_W) '$(srcdir)/test_adler32.c'; fi`
+
+test_crc32-test_crc32.o: test_crc32.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(test_crc32_CFLAGS) $(CFLAGS) -MT test_crc32-test_crc32.o -MD -MP -MF $(DEPDIR)/test_crc32-test_crc32.Tpo -c -o test_crc32-test_crc32.o `test -f 'test_crc32.c' || echo '$(srcdir)/'`test_crc32.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/test_crc32-test_crc32.Tpo $(DEPDIR)/test_crc32-test_crc32.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_crc32.c' object='test_crc32-test_crc32.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(test_crc32_CFLAGS) $(CFLAGS) -c -o test_crc32-test_crc32.o `test -f 'test_crc32.c' || echo '$(srcdir)/'`test_crc32.c
+
+test_crc32-test_crc32.obj: test_crc32.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(test_crc32_CFLAGS) $(CFLAGS) -MT test_crc32-test_crc32.obj -MD -MP -MF $(DEPDIR)/test_crc32-test_crc32.Tpo -c -o test_crc32-test_crc32.obj `if test -f 'test_crc32.c'; then $(CYGPATH_W) 'test_crc32.c'; else $(CYGPATH_W) '$(srcdir)/test_crc32.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/test_crc32-test_crc32.Tpo $(DEPDIR)/test_crc32-test_crc32.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_crc32.c' object='test_crc32-test_crc32.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(test_crc32_CFLAGS) $(CFLAGS) -c -o test_crc32-test_crc32.obj `if test -f 'test_crc32.c'; then $(CYGPATH_W) 'test_crc32.c'; else $(CYGPATH_W) '$(srcdir)/test_crc32.c'; fi`
 
 test_reset2-test_reset.o: test_reset.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(test_reset2_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT test_reset2-test_reset.o -MD -MP -MF $(DEPDIR)/test_reset2-test_reset.Tpo -c -o test_reset2-test_reset.o `test -f 'test_reset.c' || echo '$(srcdir)/'`test_reset.c
@@ -1206,7 +1246,7 @@ $(TEST_SUITE_LOG): $(TEST_LOGS)
 	  test x"$$VERBOSE" = x || cat $(TEST_SUITE_LOG);		\
 	fi;								\
 	echo "$${col}$$br$${std}"; 					\
-	echo "$${col}Testsuite summary for $(PACKAGE_STRING)$${std}";	\
+	echo "$${col}Testsuite summary"$(AM_TESTSUITE_SUMMARY_HEADER)"$${std}";	\
 	echo "$${col}$$br$${std}"; 					\
 	create_testsuite_report --maybe-color;				\
 	echo "$$col$$br$$std";						\
@@ -1471,7 +1511,6 @@ test_zeroinput.nx.log: test_zeroinput.nx
 @am__EXEEXT_TRUE@	--log-file $$b.log --trs-file $$b.trs \
 @am__EXEEXT_TRUE@	$(am__common_driver_flags) $(AM_TEST_LOG_DRIVER_FLAGS) $(TEST_LOG_DRIVER_FLAGS) -- $(TEST_LOG_COMPILE) \
 @am__EXEEXT_TRUE@	"$$tst" $(AM_TESTS_FD_REDIRECT)
-
 distdir: $(BUILT_SOURCES)
 	$(MAKE) $(AM_MAKEFLAGS) distdir-am
 
@@ -1580,9 +1619,9 @@ clean-am: clean-checkPROGRAMS clean-generic clean-libtool clean-local \
 	mostlyclean-am
 
 distclean: distclean-recursive
-		-rm -f ./$(DEPDIR)/test_adler32.Po
+		-rm -f ./$(DEPDIR)/test_adler32-test_adler32.Po
 	-rm -f ./$(DEPDIR)/test_buf_error.Po
-	-rm -f ./$(DEPDIR)/test_crc32.Po
+	-rm -f ./$(DEPDIR)/test_crc32-test_crc32.Po
 	-rm -f ./$(DEPDIR)/test_deflate.Po
 	-rm -f ./$(DEPDIR)/test_dict.Po
 	-rm -f ./$(DEPDIR)/test_gz.Po
@@ -1650,9 +1689,9 @@ install-ps-am:
 installcheck-am:
 
 maintainer-clean: maintainer-clean-recursive
-		-rm -f ./$(DEPDIR)/test_adler32.Po
+		-rm -f ./$(DEPDIR)/test_adler32-test_adler32.Po
 	-rm -f ./$(DEPDIR)/test_buf_error.Po
-	-rm -f ./$(DEPDIR)/test_crc32.Po
+	-rm -f ./$(DEPDIR)/test_crc32-test_crc32.Po
 	-rm -f ./$(DEPDIR)/test_deflate.Po
 	-rm -f ./$(DEPDIR)/test_dict.Po
 	-rm -f ./$(DEPDIR)/test_gz.Po


### PR DESCRIPTION
These are trivial fixes.

I verified they compile, but I can't run the tests because I don't have access to systems with NX GZIP anymore. Could you run the tests please?