### PR TITLE
lib/nx_crc : Fix compile error with gcc15

### DIFF
--- a/lib/nx_crc.c
+++ b/lib/nx_crc.c
@@ -275,10 +275,7 @@ unsigned long nx_crc32(unsigned long crc, const unsigned char FAR *buf,
 #define DOLIT32 DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4
 
 /* ========================================================================= */
-local unsigned long crc32_little(crc, buf, len)
-    unsigned long crc;
-    const unsigned char FAR *buf;
-    z_size_t len;
+local unsigned long crc32_little( unsigned long crc, const unsigned char FAR *buf, z_size_t len)
 {
     register z_crc_t c;
     register const z_crc_t FAR *buf4;
@@ -315,10 +312,7 @@ local unsigned long crc32_little(crc, buf, len)
 #define DOBIG32 DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4
 
 /* ========================================================================= */
-local unsigned long crc32_big(crc, buf, len)
-    unsigned long crc;
-    const unsigned char FAR *buf;
-    z_size_t len;
+local unsigned long crc32_big( unsigned long crc, const unsigned char FAR *buf, z_size_t len)
 {
     register z_crc_t c;
     register const z_crc_t FAR *buf4;


### PR DESCRIPTION
With newer gcc versions e.g. gcc15, make fails with following error
error: old-style function definition [-Werror=old-style-definition]

Change the function declaration to fix this error

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>