### PR TITLE
nx_inflate.c: Submit job to nx when flush parameters are Z_{FULL,PART…IAL}_FLUSH [#203]

### DIFF
--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -1197,7 +1197,10 @@ copy_fifo_out_to_next_out:
 	if (s->avail_in > 0
 	    && (s->avail_in + s->used_in < nx_config.cache_threshold)
 	    && s->avail_out > 0
-	    && flush != Z_FINISH && flush != Z_SYNC_FLUSH) {
+	    && flush != Z_FINISH
+	    && flush != Z_FULL_FLUSH
+	    && flush != Z_SYNC_FLUSH
+	    && flush != Z_PARTIAL_FLUSH) {
 		/* We haven't accumulated enough data. Cache any input data
 		   provided and wait for the application to send more in order
 		   to reduce the amount of requests sent to the accelerator. */


### PR DESCRIPTION
After commit 94573fe, which allowed (de)compression of streams even if avail_in < threshold, a latent bug in inflate logic was exposed, which was found during integration test with open-jdk.

This patch fixes this issue in nx_inflate_ by adding checks to see if the flush is also not Z_{FULL,PARTIAL}_FLUSH along with Z_FINISH and Z_SYNC_FLUSH, when pushing the data to fifo.