### PR TITLE
Cherry pick commits in 0.63-2 into master

### DIFF
--- a/lib/Versions
+++ b/lib/Versions
@@ -58,6 +58,7 @@ LIBNXZ_0.61.0 {
 
 LIBNXZ_0.63.0 {
     nx_inflateSyncPoint;
+    nx_deflateParams;
 } LIBNXZ_0.61.0;
 
 LIBNXZ_0.64.0 {
@@ -66,6 +67,7 @@ LIBNXZ_0.64.0 {
     nx_gzdopen;
     nx_gzread;
     nx_gzwrite;
+    nx_deflateParams;
 } LIBNXZ_0.63.0;
 
 ZLIB_1.2.0 {

--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -1643,8 +1643,8 @@ int nx_deflate(z_streamp strm, int flush)
 		return Z_STREAM_ERROR;
 
 	/* check for sw deflate first */
-	if (has_nx_state(strm) && s->switchable
-	    && (0 == use_nx_deflate(strm, flush))) {
+	if ((has_nx_state(strm)) && s->switchable
+	&& (0 == use_nx_deflate(strm, flush) || 0 == s->level)) {
 		/* Use software zlib, switch the sw and hw state */
 		nx_switch_to_sw(strm);
 
@@ -1919,15 +1919,7 @@ int nx_deflateParams(z_streamp strm, int level, int strategy)
        if (strategy == Z_FILTERED || strategy == Z_RLE || strategy == Z_HUFFMAN_ONLY)
                strategy = Z_DEFAULT_STRATEGY;
 
-       /* Empty the contents of buffer */
-       int err = deflate(strm, Z_BLOCK);
-       if (err == Z_STREAM_ERROR)
-	       return err;
-
-       if (strm->avail_in)
-	       return Z_BUF_ERROR;
-
-       if (s->level != level)
+       if (level !=0 && s->level != level)
 	       s->level = level;
 
        s->strategy = strategy;

--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -2611,10 +2611,15 @@ int deflateSetHeader(z_streamp strm, gz_headerp head)
 int deflateSetDictionary(z_streamp strm, const Bytef *dictionary, uInt  dictLength)
 {
 	int rc;
+	nx_streamp s;
+
+	s = (nx_streamp) strm->state;
 
 	if (0 == has_nx_state(strm)){
 		rc = sw_deflateSetDictionary(strm, dictionary, dictLength);
 	}else{
+		if (s == Z_NULL) return Z_STREAM_ERROR;
+		s->switchable = 0;
 		rc = nx_deflateSetDictionary(strm, dictionary, dictLength);
 	}
 

--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -1900,6 +1900,42 @@ s2:
 	return Z_STREAM_ERROR;
 }
 
+int nx_deflateParams(z_streamp strm, int level, int strategy)
+{
+       int rc = Z_OK;
+       nx_streamp s;
+
+
+       s = (nx_streamp) strm->state;
+
+       if (level == Z_DEFAULT_COMPRESSION) level = 6;
+
+       if (level < 0 || level > 9)
+               return Z_STREAM_ERROR;
+
+       if (strategy < Z_DEFAULT_STRATEGY || strategy > Z_FIXED)
+               return Z_STREAM_ERROR;
+
+       if (strategy == Z_FILTERED || strategy == Z_RLE || strategy == Z_HUFFMAN_ONLY)
+               strategy = Z_DEFAULT_STRATEGY;
+
+       /* Empty the contents of buffer */
+       int err = deflate(strm, Z_BLOCK);
+       if (err == Z_STREAM_ERROR)
+	       return err;
+
+       if (strm->avail_in)
+	       return Z_BUF_ERROR;
+
+       if (s->level != level)
+	       s->level = level;
+
+       s->strategy = strategy;
+
+       return rc;
+}
+
+
 /* from zlib.h deflateBound() returns an upper bound on the compressed
    size after deflation of sourceLen bytes.  It must be called after
    deflateInit() or deflateInit2(), and after deflateSetHeader(), if
@@ -2535,6 +2571,25 @@ unsigned long deflateBound(z_streamp strm, unsigned long sourceLen)
 		rc = sw_deflateBound(strm, sourceLen);
 	}else{
 		rc = nx_deflateBound(strm, sourceLen);
+	}
+
+	return rc;
+}
+
+int deflateParams(z_streamp strm, int level, int strategy)
+{
+	unsigned long rc;
+	nx_streamp s;
+
+	if (strm == Z_NULL) return Z_STREAM_ERROR;
+
+	s = (nx_streamp) strm->state;
+	if (s == Z_NULL) return Z_STREAM_ERROR;
+
+	if (0 == has_nx_state(strm)){
+		rc = sw_deflateParams(strm, level, strategy);
+	}else{
+		rc = nx_deflateParams(strm, level, strategy);
 	}
 
 	return rc;

--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -2346,12 +2346,16 @@ int deflateInit2_(z_streamp strm, int level, int method, int windowBits,
 			/* TODO: need to free sme and etc.? */
 			return Z_MEM_ERROR;
 		}
-	} else if (nx_config.mode.deflate == GZIP_NX) {
-		rc = nx_deflateInit2_(strm, level, method, windowBits, memLevel,
-				      strategy, version, stream_size);
-	} else {
-		rc = sw_deflateInit2_(strm, level, method, windowBits, memLevel,
-				      strategy, version, stream_size);
+	}else if(nx_config.mode.deflate == GZIP_NX){
+		rc = nx_deflateInit2_(strm, level, method, windowBits, memLevel, strategy, version, stream_size);
+	}else{
+		rc = sw_deflateInit2_(strm, level, method, windowBits, memLevel, strategy, version, stream_size);
+		if (rc != Z_OK)
+			return rc;
+		if (strm->state && (0 == has_nx_state(strm))){
+			s = (nx_streamp) strm->state;
+			s->switchable = 1;
+		}
 	}
 
 	return rc;

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -285,8 +285,8 @@ int nx_inflate(z_streamp strm, int flush)
 
 	/* check for sw deflate first*/
 	if (has_nx_state(strm) && s->switchable
-	    && (0 == use_nx_inflate(strm, flush))) {
-		/* Use software zlib, switch the sw and hw state */
+	&& (0 == use_nx_inflate(strm, flush) || 0 == s->level)) {
+		/*Use software zlib, switch the sw and hw state*/
 		s = (nx_streamp) strm->state;
 		s->switchable = 0; /* decided to use sw zlib and not switchable */
 		strm->state = s->sw_stream;  /* use sw internal state */

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -1197,7 +1197,10 @@ copy_fifo_out_to_next_out:
 	if (s->avail_in > 0
 	    && (s->avail_in + s->used_in < nx_config.cache_threshold)
 	    && s->avail_out > 0
-	    && flush != Z_FINISH && flush != Z_SYNC_FLUSH) {
+	    && flush != Z_FINISH
+	    && flush != Z_FULL_FLUSH
+	    && flush != Z_SYNC_FLUSH
+	    && flush != Z_PARTIAL_FLUSH) {
 		/* We haven't accumulated enough data. Cache any input data
 		   provided and wait for the application to send more in order
 		   to reduce the amount of requests sent to the accelerator. */

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -661,6 +661,7 @@ extern int nx_deflateInit2_(z_streamp strm, int level, int method, int windowBit
 extern int nx_deflate(z_streamp strm, int flush);
 extern int nx_deflateEnd(z_streamp strm);
 extern unsigned long nx_deflateBound(z_streamp strm, unsigned long sourceLen);
+extern int nx_deflateParams(z_streamp strm, int level, int strategy);
 extern int nx_deflateSetDictionary(z_streamp strm, const unsigned char *dictionary,
 				uint dictLength);
 extern int nx_deflateReset(z_streamp strm);
@@ -712,6 +713,7 @@ extern int sw_deflateReset(z_streamp strm);
 extern int sw_deflateResetKeep(z_streamp strm);
 extern int sw_deflateSetHeader(z_streamp strm, gz_headerp head);
 extern uLong sw_deflateBound(z_streamp strm, uLong sourceLen);
+extern int sw_deflateParams(z_streamp strm, int level, int strategy);
 extern int sw_deflateSetDictionary(z_streamp strm, const Bytef *dictionary, uInt  dictLength);
 extern int sw_deflateCopy(z_streamp dest, z_streamp source);
 extern int sw_uncompress(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen);

--- a/lib/sw_zlib.c
+++ b/lib/sw_zlib.c
@@ -109,6 +109,13 @@ uLong sw_deflateBound(z_streamp strm, uLong sourceLen)
 	return (* p_deflateBound)(strm, sourceLen);
 }
 
+static int (* p_deflateParams)(z_streamp strm, int level, int strategy);
+int sw_deflateParams(z_streamp strm, int level, int strategy)
+{
+       check_sym(p_deflateParams, Z_STREAM_ERROR);
+       return (* p_deflateParams)(strm, level, strategy);
+}
+
 static int (* p_deflateReset)(z_streamp strm);
 int sw_deflateReset(z_streamp strm)
 {
@@ -297,6 +304,7 @@ int sw_zlib_init(void)
 	register_sym(deflateReset);
 	register_sym(deflateResetKeep);
 	register_sym(deflateBound);
+	register_sym(deflateParams);
 	register_sym(deflateSetHeader);
 	register_sym(deflate);
 	register_sym(deflateEnd);

--- a/libnxz.h
+++ b/libnxz.h
@@ -70,6 +70,7 @@ extern int nx_deflateInit2_(void *strm, int level, int method, int windowBits,
 extern int nx_deflate(void *strm, int flush);
 extern int nx_deflateEnd(void *strm);
 extern ulong nx_deflateBound(void *strm, ulong sourceLen);
+extern int nx_deflateParams(z_streamp strm, int level, int strategy);
 extern int nx_deflateSetHeader(void *strm, void *head);
 extern int nx_deflateCopy(void *dest, void *source);
 extern int nx_deflateReset(void *strm);
@@ -125,6 +126,7 @@ extern int deflateReset(void *strm);
 extern int deflateEnd(void *strm);
 extern int deflate(void *strm, int flush);
 extern ulong deflateBound(void *strm, ulong sourceLen);
+extern int deflateParams(void *strm, int level, int strategy);
 extern int deflateSetHeader(void *strm, void *head);
 extern int deflateSetDictionary(void *strm, const unsigned char *dictionary,
 				uint  dictLength);

--- a/test/test_abi
+++ b/test/test_abi
@@ -53,4 +53,4 @@ echo "Checking missing zlib symbols..."
 abidiff --suppressions "${zlib_supp}" --no-added-syms ${zlib_abi} ${libnxz}
 
 echo "Checking changes on libnxz's ABI..."
-abidiff ${libnxz_abi} ${libnxz}
+abidiff --no-added-syms ${libnxz_abi} ${libnxz}


### PR DESCRIPTION
The fixes in 0.63-2 were mostly for open-jdk integration tests. I have cherry-picked all relevant commits (except the reverted ones). 

Also this depends on the PR #215, since without that none of that jdk tests work, therefore that has been applied before cherry picking any of the commits in 0.63-2.