### PR TITLE
nx_deflate.c: Reset history_len to 0 in deflateResetKeep and deflateInit

### DIFF
--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -512,6 +512,7 @@ static int nx_deflateResetKeep(z_streamp strm)
 
 	s->used_in = s->used_out = 0;
 	s->cur_in  = s->cur_out = 0;
+	s->history_len = 0;
 	s->tebc = 0;
 	s->is_final = 0;
 
@@ -700,6 +701,7 @@ int nx_deflateInit2_(z_streamp strm, int level, int method, int windowBits,
 
 	s->used_in = s->used_out = 0;
 	s->cur_in  = s->cur_out = 0;
+	s->history_len = 0;
 	s->tebc = 0;
 
 	s->ddl_in = s->dde_in;


### PR DESCRIPTION
The jdk test DeInflate.java exposed this issue where the cur_in=0 and history_len=4096, which caused an assertion failure in nx_setup_ddl_in.

This patch makes sure the state of the stream is consistent when deflateResetKeep of deflateInit is done i.e., initialize/reset the value of history_len to 0 when cur_in is set to 0.