### PR TITLE
nx_inflate.c: Submit job to nx when flush parameters are Z_{FULL,PARTIAL}_FLUSH [#203]

### DIFF
--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -1188,16 +1188,17 @@ copy_fifo_out_to_next_out:
 	   Avoid executing this code when avail_in is 0.  That means either the
 	   end of the stream or the end of the current request.  There is
 	   nothing to copy anyway.
-	   Likewise when flush is either Z_FINISH or Z_SYNC_FLUSH.  In these
-	   cases, inflate is expected to provide an output and copying data to
-	   fifo_in would just add unnecessary delays.
+	   Cache the input in fifo_in only when flush value is Z_NO_FLUSH.
+	   All other flush modes i.e., Z_SYNC_FLUSH, Z_PARTIAL_FLUSH, Z_FINISH
+	   and Z_FULL_FLUSH require immediate output and therefore must be
+	   submitted to NX and not fifo_in.
 	   The following code is not just an optimization, it is also required
 	   by NX because it may refuse to start processing a stream if the input
 	   is not large enough.  */
 	if (s->avail_in > 0
 	    && (s->avail_in + s->used_in < nx_config.cache_threshold)
 	    && s->avail_out > 0
-	    && flush != Z_FINISH && flush != Z_SYNC_FLUSH) {
+	    && flush == Z_NO_FLUSH) {
 		/* We haven't accumulated enough data. Cache any input data
 		   provided and wait for the application to send more in order
 		   to reduce the amount of requests sent to the accelerator. */


### PR DESCRIPTION
After commit 94573fe, which allowed (de)compression of streams even if avail_in < threshold, a latent bug in inflate logic was exposed, which was found during integration test with open-jdk.
This patch fixes this issue in nx_inflate_ by adding checks to see if the flush is also not Z_{FULL,PARTIAL}_FLUSH along with Z_FINISH and Z_SYNC_FLUSH, when pushing the data to fifo.

The util.zip library in open-jdk sends the flush value as `Z_PARTIAL_FLUSH` with the initial call to inflate/deflate. Due to this, the `use_nx_inflate`  function which helps decide whether to use software or nx for the further sequence of inflate/deflate until `Z_FINISH` decides to use nx even for small data.

For example, a simple test case: https://github.com/openjdk/jdk/blob/master/test/jdk/java/util/zip/ZipFile/ShortRead.java
Even for such small data, the open-jdk sends the following sequence for compression
```
nx_deflate:1671 avail_in 15 total_in 0 used_in 0 cur_in 0 avail_out 512 total_out 0 used_out 0 cur_out 0 len_in 0 len_out 4194304 flush 0, actual flush value 1 (Z_PARTIAL_FLUSH)
```

The use_nx_inflate decides to use nx for this case, and since the cache_threshold is not met, it never flushes out of the fifo, and thus triggering the EOFException.


