### PR TITLE
Add public endpoint tracing capability for better debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ Use `export NX_GZIP_TRACE=1` to enable logic trace.
 
 Use `export NX_GZIP_TRACE=8` to enable statistics trace.
 
+Sometimes, a sequence of public api call sequence may be needed to reproduce
+some issues such as when the library is used with other languages/sdk like
+JDK. In those situations, build the library with public api trace support
+```
+./configure CFLAGS="-DNX_API_TRACE"
+```
+Then use `export NX_GZIP_VERBOSE=2` to observe the sequence of public api calls
+in the log file.
+
 ## Supported Functions List
 
 All the zlib supported functions are listed and described at libnxz.h.

--- a/inc_nx/nx_dbg.h
+++ b/inc_nx/nx_dbg.h
@@ -112,6 +112,15 @@ extern pthread_mutex_t mutex_log;
 	prt("### "fmt, ## __VA_ARGS__);					\
 }} while (0)
 
+/* Trace public API entry points - compile-time conditional for zero overhead */
+#ifdef NX_API_TRACE
+#define prt_api_entry(func, fmt, ...) \
+	prt_info(">>> API ENTRY: %s(" fmt ")\n", func, ## __VA_ARGS__)
+#else
+#define prt_api_entry(func, fmt, ...)
+#endif
+
+
 /**
  * str_to_num - Convert string into number and copy with endings like
  *              KiB for kilobyte

--- a/lib/nx_deflate.c
+++ b/lib/nx_deflate.c
@@ -2275,6 +2275,11 @@ int deflateInit2_(z_streamp strm, int level, int method, int windowBits,
 	void *sw_state = NULL;
 	nx_streamp s;
 
+	prt_api_entry("deflateInit2_", "strm=%p, level=%d, method=%d, windowBits=%d,"
+			"memLevel=%d, strategy=%d, version=%s, stream_size=%d",
+			strm, level, method, windowBits, memLevel, strategy, version, stream_size);
+	print_zstream_info(strm, __LINE__);
+
 	/* statistic */
 	zlib_stats_inc(&zlib_stats.deflateInit);
 
@@ -2357,6 +2362,9 @@ int deflateInit2_(z_streamp strm, int level, int method, int windowBits,
 int deflateReset(z_streamp strm)
 {
 	int rc;
+
+	prt_api_entry("deflateReset", "strm=%p", strm);
+	print_zstream_info(strm, __LINE__);
 
 	if (nx_config.mode.deflate == GZIP_AUTO) {
 		struct stream_map_entry *sme;
@@ -2454,6 +2462,8 @@ int deflateReset(z_streamp strm)
 */
 int deflateResetKeep(z_streamp strm)
 {
+	prt_api_entry("deflateResetKeep", "strm=%p", strm);
+	print_zstream_info(strm, __LINE__);
 	if (has_nx_state(strm))
 		return nx_deflateResetKeep(strm);
 	else
@@ -2463,6 +2473,8 @@ int deflateResetKeep(z_streamp strm)
 int deflateEnd(z_streamp strm)
 {
 	int rc;
+	prt_api_entry("deflateEnd", "strm=%p", strm);
+	print_zstream_info(strm, __LINE__);
 
 	/* statistic */
 	zlib_stats_inc(&zlib_stats.deflateEnd);
@@ -2508,6 +2520,9 @@ int deflate(z_streamp strm, int flush)
 	unsigned int avail_in_slot, avail_out_slot;
 	uint64_t t1=0, t2, t_diff;
 	unsigned int avail_in=0, avail_out=0;
+
+	prt_api_entry("deflate", "strm=%p, flush=%d", strm, flush);
+	print_zstream_info(strm, __LINE__);
 
 	/* statistic */
 	if (nx_gzip_gather_statistics()) {
@@ -2559,6 +2574,8 @@ unsigned long deflateBound(z_streamp strm, unsigned long sourceLen)
 {
 	unsigned long rc;
 
+	prt_api_entry("deflateBound", "strm=%p, sourceLen=%lu", strm, sourceLen);
+	print_zstream_info(strm, __LINE__);
 	if (strm == NULL) {
 		return NX_MAX(nx_deflateBound(NULL, sourceLen),
 		           sw_deflateBound(NULL, sourceLen));
@@ -2575,6 +2592,8 @@ unsigned long deflateBound(z_streamp strm, unsigned long sourceLen)
 
 int deflateParams(z_streamp strm, int level, int strategy)
 {
+	prt_api_entry("deflateParams", "strm=%p, level=%d, strategy=%d", strm, level, strategy);
+	print_zstream_info(strm, __LINE__);
 	unsigned long rc;
 	nx_streamp s;
 
@@ -2594,6 +2613,8 @@ int deflateParams(z_streamp strm, int level, int strategy)
 
 int deflateSetHeader(z_streamp strm, gz_headerp head)
 {
+	prt_api_entry("deflateSetHeader", "strm=%p", strm);
+	print_zstream_info(strm, __LINE__);
 	int rc;
 
 	if (0 == has_nx_state(strm)){
@@ -2609,6 +2630,10 @@ int deflateSetDictionary(z_streamp strm, const Bytef *dictionary, uInt  dictLeng
 {
 	int rc;
 	nx_streamp s;
+
+	prt_api_entry("deflateSetDictionary", "strm=%p, dictionary=%p, dictLength=%u",
+		      strm, dictionary, dictLength);
+	print_zstream_info(strm, __LINE__);
 
 	s = (nx_streamp) strm->state;
 
@@ -2626,6 +2651,9 @@ int deflateSetDictionary(z_streamp strm, const Bytef *dictionary, uInt  dictLeng
 int deflateCopy(z_streamp dest, z_streamp source)
 {
 	int rc;
+
+	prt_api_entry("deflateCopy", "dest=%p, source=%p", dest, source);
+	print_zstream_info(source, __LINE__);
 
 	if (0 == has_nx_state(source)){
 		rc = sw_deflateCopy(dest, source);

--- a/lib/nx_inflate.c
+++ b/lib/nx_inflate.c
@@ -1990,6 +1990,8 @@ int inflateInit2_(z_streamp strm, int windowBits, const char *version, int strea
 	void *sw_state = NULL;
 	nx_streamp s;
 
+	prt_api_entry("inflateInit2_", "strm=%p, version=%s, stream_size=%d", strm, version, stream_size);
+	print_zstream_info(strm, __LINE__);
 	/* statistic */
 	zlib_stats_inc(&zlib_stats.inflateInit);
 
@@ -2056,6 +2058,9 @@ int inflateInit2_(z_streamp strm, int windowBits, const char *version, int strea
 int inflateReset(z_streamp strm)
 {
 	int rc;
+
+	prt_api_entry("inflateReset", "strm=%p", strm);
+	print_zstream_info(strm, __LINE__);
 
 	if (nx_config.mode.inflate == GZIP_AUTO) {
 		struct stream_map_entry *sme;
@@ -2151,6 +2156,8 @@ int inflateReset(z_streamp strm)
 */
 int inflateResetKeep(z_streamp strm)
 {
+	prt_api_entry("inflateResetKeep", "strm=%p", strm);
+	print_zstream_info(strm, __LINE__);
 	if (has_nx_state(strm))
 		return nx_inflateResetKeep(strm);
 	else
@@ -2159,6 +2166,8 @@ int inflateResetKeep(z_streamp strm)
 
 int inflateReset2(z_streamp strm, int windowBits)
 {
+	prt_api_entry("inflateReset2", "strm=%p, windowBits=%d", strm, windowBits);
+	print_zstream_info(strm, __LINE__);
 	int rc;
 
 	if (nx_config.mode.inflate == GZIP_AUTO) {
@@ -2222,6 +2231,9 @@ int inflateEnd(z_streamp strm)
 {
 	int rc;
 
+	prt_api_entry("inflateEnd", "strm=%p", strm);
+	print_zstream_info(strm, __LINE__);
+
 	/* statistic */
 	zlib_stats_inc(&zlib_stats.inflateEnd);
 
@@ -2265,6 +2277,9 @@ int inflate(z_streamp strm, int flush)
 	unsigned int avail_in_slot, avail_out_slot;
 	uint64_t t1=0, t2, t_diff;
 	unsigned int avail_in=0, avail_out=0;
+
+	prt_api_entry("inflate", "strm=%p, flush=%d", strm, flush);
+	print_zstream_info(strm, __LINE__);
 
 	if (strm == NULL || strm->state == NULL) return Z_STREAM_ERROR;
 
@@ -2316,6 +2331,10 @@ int inflateSetDictionary(z_streamp strm, const Bytef *dictionary, uInt dictLengt
 {
 	int rc;
 
+	prt_api_entry("inflateSetDictionary", "strm=%p, dictionary=%p, dictLength=%u",
+		      strm, dictionary, dictLength);
+	print_zstream_info(strm, __LINE__);
+
 	if (0 == has_nx_state(strm)){
 		rc = sw_inflateSetDictionary(strm, dictionary, dictLength);
 	}else{
@@ -2328,6 +2347,9 @@ int inflateSetDictionary(z_streamp strm, const Bytef *dictionary, uInt dictLengt
 int inflateCopy(z_streamp dest, z_streamp source)
 {
 	int rc;
+
+	prt_api_entry("inflateCopy", "dest=%p, source=%p", dest, source);
+	print_zstream_info(source, __LINE__);
 
 	if (0 == has_nx_state(source)){
 		rc = sw_inflateCopy(dest, source);
@@ -2342,6 +2364,9 @@ int inflateGetHeader(z_streamp strm, gz_headerp head)
 {
 	int rc;
 
+	prt_api_entry("inflateGetHeader", "strm=%p, head=%p", strm, head);
+	print_zstream_info(strm, __LINE__);
+
 	if (0 == has_nx_state(strm)){
 		rc = sw_inflateGetHeader(strm, head);
 	}else{
@@ -2354,6 +2379,9 @@ int inflateGetHeader(z_streamp strm, gz_headerp head)
 int inflateSyncPoint(z_streamp strm)
 {
 	int rc;
+
+	prt_api_entry("inflateSyncPoint", "strm=%p", strm);
+	print_zstream_info(strm, __LINE__);
 
 	if (0 == has_nx_state(strm))
 		rc = sw_inflateSyncPoint(strm);

--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -524,6 +524,18 @@ len_in %ld len_out %ld flush %d\n", __FUNCTION__, line, \
 (long)(s)->len_in, (long)(s)->len_out, (s)->flush);	\
 } while (0)
 
+/* Print z_stream state information for API tracing - compile-time conditional for zero overhead */
+#ifdef NX_API_TRACE
+#define print_zstream_info(strm, line) \
+do { if (strm) prt_info(\
+"== %s:%d z_stream: avail_in %u total_in %lu avail_out %u total_out %lu\n", \
+__FUNCTION__, line, \
+(strm)->avail_in, (strm)->total_in, (strm)->avail_out, (strm)->total_out); \
+} while (0)
+#else
+#define print_zstream_info(strm, line)
+#endif
+
 
 /* inflate states */
 typedef enum {


### PR DESCRIPTION
    It is hard to reproduce the test cases just by observing the logs right
    now, specially in cases where other languages like Java uses this
    library.
    This commit tries to make it easier to debug in such scenarios by adding
    logs at each public api entry point. We can further use the log to
    generate a test case in C, if required.