### PR TITLE
Revert changes in 94573fe

### DIFF
--- a/lib/nx_zlib.h
+++ b/lib/nx_zlib.h
@@ -391,7 +391,7 @@ static inline int use_nx_inflate(z_streamp strm, int flush)
 	   inflate() may not have enough input. So, avoid switching to software
 	   decompression prematurely unless there is a guarantee that all the
 	   input has been provided, i.e. when using Z_FINISH. */
-	if(flush == Z_FINISH && strm->avail_in <= DECOMPRESS_THRESHOLD)
+	if(strm->avail_in <= DECOMPRESS_THRESHOLD)
 		return 0;
 
 	return 1;
@@ -415,7 +415,7 @@ static inline int use_nx_deflate(z_streamp strm, int flush)
 	   deflate() may not have enough input. So, avoid switching to software
 	   compression prematurely unless there is a guarantee that all the
 	   input has been provided, i.e. when using Z_FINISH. */
-	if(flush == Z_FINISH && strm->avail_in <= COMPRESS_THRESHOLD)
+	if(strm->avail_in <= COMPRESS_THRESHOLD)
 		return 0;
 
 	return 1;


### PR DESCRIPTION
Commit 94573fe tried to reduce the scope of SW usage on length threashold. However, there was no actual test case which tested this change.
While integrating with JDK, there was a failure on CopyZipFile.java, and certain other places, where the data is small, but the api calls done is in a way that for small data as well, hardware path is taken. For e.g., data of 12 bytes size, is sent as 2 deflate calls, first with avail_in = 12 and Z_NO_FLUSH, and second call is avail_in = 0, total_in = 12 and Z_FINISH.
Ideally this should have been handled by software. Thus reverting this fix for now to completely integrate with openJDK.